### PR TITLE
Make structs pickable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ crate-type = ["cdylib"]
 pyo3 = "0.23.4"
 rand = "0.8.5"
 rustc-hash = "2.1.0"
+bincode = "1.3.3"
+serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Rationale
A pickable object should be useful in multiprocessing environments or when caching is needed.

## Changes
- Added magic methods `__setstate__`, `__getstate__`, `__getnewargs__` for them to be pickable