### PR TITLE
Add OptDensMinHash algorithm and benchmark

### DIFF
--- a/benchmarks/simple_benchmark.py
+++ b/benchmarks/simple_benchmark.py
@@ -2,7 +2,7 @@ import time
 
 from datasets import load_dataset
 from datasketch import MinHash
-from rensa import CMinHash, RMinHash
+from rensa import CMinHash, RMinHash, OptDensMinHash
 from tqdm import tqdm
 
 
@@ -21,6 +21,12 @@ def rensa_minhash(text, num_perm=128):
 
 def cminimash(text, num_perm=128):
     m = CMinHash(num_perm=num_perm, seed=42)
+    m.update(text.split())
+    return m
+
+
+def optdens_minhash(text, num_perm=128):
+    m = OptDensMinHash(num_perm=num_perm, seed=42)
     m.update(text.split())
     return m
 
@@ -71,6 +77,11 @@ def run_benchmark():
         sql_dataset, cminimash, desc="Rensa C-MinHash"
     )
 
+    print("\nRunning Rensa (OptDens-MinHash) benchmark...")
+    optdens_results = benchmark_deduplication(
+        sql_dataset, optdens_minhash, desc="Rensa OptDens-MinHash"
+    )
+
     print("\n" + "=" * 60)
     print("BENCHMARK RESULTS")
     print("=" * 60)
@@ -80,6 +91,7 @@ def run_benchmark():
         ("Datasketch", datasketch_results),
         ("R-MinHash", rensa_results),
         ("C-MinHash", cminimash_results),
+        ("OptDens-MinHash", optdens_results),
     ]
 
     for name, result in results:

--- a/tests/test_rensa.py
+++ b/tests/test_rensa.py
@@ -1,4 +1,4 @@
-from rensa import RMinHash, RMinHashLSH
+from rensa import RMinHash, RMinHashLSH, OptDensMinHash
 
 
 def test_rminhash_creation():
@@ -83,3 +83,19 @@ def test_rminhashlsh_is_similar():
     jaccard_value = m1.jaccard(m2)
     assert lsh.is_similar(m1, m2) == (
         jaccard_value >= 0.8), "Check LSH threshold vs real jaccard"
+
+
+def test_optdensminhash_similarity():
+    m1 = OptDensMinHash(num_perm=8, seed=1)
+    m2 = OptDensMinHash(num_perm=8, seed=1)
+    m1.update(["apple", "banana"])
+    m2.update(["apple", "banana"])
+    assert abs(m1.jaccard(m2) - 1.0) < 1e-9
+
+
+def test_optdensminhash_difference():
+    m1 = OptDensMinHash(num_perm=8, seed=1)
+    m2 = OptDensMinHash(num_perm=8, seed=1)
+    m1.update(["foo"])
+    m2.update(["bar"])
+    assert m1.jaccard(m2) < 0.5


### PR DESCRIPTION
## Summary
- implement `OptDensMinHash` in Rust with pyo3 bindings
- expose the new class from the `rensa` module
- benchmark the algorithm in `simple_benchmark.py`
- add basic tests for `OptDensMinHash`

## Testing
- `cargo build --quiet`
- `source .venv/bin/activate && maturin develop --release --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aa0742dd4833298ce7930f86088cb