### PR TITLE
Use bumpalo for temporary buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 murmur3 = "0.5.2"
 rand_xoshiro = "0.7.0"
 rand_chacha = "0.9.0"
+bumpalo = "3.14.0"
 
 [profile.release]
 lto = "fat"

--- a/src/cminhash.rs
+++ b/src/cminhash.rs
@@ -21,6 +21,8 @@ use pyo3::types::PyBytes;
 use rand::prelude::*;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use serde::{Deserialize, Serialize};
+use bumpalo::Bump;
+use bumpalo::collections::Vec as BumpVec;
 
 /// CMinHash implements an optimized version of C-MinHash with better memory access patterns
 /// and aggressive optimizations for maximum single-threaded performance.
@@ -83,7 +85,8 @@ impl CMinHash {
   pub fn update(&mut self, items: Vec<String>) {
     // Batch hash computation
     const BATCH_SIZE: usize = 32;
-    let mut hash_batch = Vec::with_capacity(BATCH_SIZE);
+    let bump = Bump::new();
+    let mut hash_batch = BumpVec::with_capacity_in(BATCH_SIZE, &bump);
 
     for chunk in items.chunks(BATCH_SIZE) {
       hash_batch.clear();

--- a/src/rminhash.rs
+++ b/src/rminhash.rs
@@ -32,6 +32,8 @@ use pyo3::types::PyBytes;
 use rand::prelude::*;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use serde::{Deserialize, Serialize};
+use bumpalo::Bump;
+use bumpalo::collections::Vec as BumpVec;
 
 const PERM_CHUNK_SIZE: usize = 16;
 
@@ -81,7 +83,8 @@ impl RMinHash {
   /// * `items` - A vector of strings to be hashed and incorporated into the MinHash.
   pub fn update(&mut self, items: Vec<String>) {
     const BATCH_SIZE: usize = 32;
-    let mut hash_batch = Vec::with_capacity(BATCH_SIZE);
+    let bump = Bump::new();
+    let mut hash_batch = BumpVec::with_capacity_in(BATCH_SIZE, &bump);
 
     // Process items in batches for better cache utilization
     for chunk in items.chunks(BATCH_SIZE) {


### PR DESCRIPTION
## Summary
- add `bumpalo` dependency
- use bump allocation in `RMinHash::update`
- use bump allocation in `CMinHash::update`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rensa')*

------
https://chatgpt.com/codex/tasks/task_e_683b49da1b988332b03db8bb012b50f9