### PR TITLE
Add inline deduplication helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,23 @@ if __name__ == "__main__":
     main_direct_deduplication()
 ```
 
+### Inline Deduplication
+
+For streaming scenarios you can deduplicate records as they arrive using the new
+`*Deduper` classes. They work with `RMinHash`, `CMinHash`, or `OptDensMinHash`:
+
+```python
+from rensa import RMinHashDeduper
+
+deduper = RMinHashDeduper(num_perm=128, seed=42)
+
+tokens = "a new record".split()
+if deduper.add(tokens):
+    print("unique")
+else:
+    print("duplicate")
+```
+
 ### Using C-MinHash for Similarity
 
 Here's a more direct example of using `CMinHash` for calculating Jaccard similarity:

--- a/src/cminhash.rs
+++ b/src/cminhash.rs
@@ -151,6 +151,11 @@ impl CMinHash {
     self.hash_values.clone()
   }
 
+  /// Resets the internal state so the object can be reused for new data.
+  pub fn clear(&mut self) {
+    self.hash_values.fill(u64::MAX);
+  }
+
   /// Calculates the Jaccard similarity between this CMinHash and another.
   #[inline]
   #[must_use]

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -1,0 +1,100 @@
+use crate::{CMinHash, OptDensMinHash, RMinHash};
+use pyo3::prelude::*;
+use std::collections::HashSet;
+
+/// Inline deduplicator using `RMinHash`.
+#[pyclass(module = "rensa")]
+pub struct RMinHashDeduper {
+    num_perm: usize,
+    seed: u64,
+    #[pyo3(get)]
+    seen: HashSet<Vec<u32>>, 
+    rminhash: RMinHash,
+}
+
+#[pymethods]
+impl RMinHashDeduper {
+    #[new]
+    #[must_use]
+    pub fn new(num_perm: usize, seed: u64) -> Self {
+        Self {
+            num_perm,
+            seed,
+            seen: HashSet::new(),
+            rminhash: RMinHash::new(num_perm, seed),
+        }
+    }
+
+    /// Adds a new record. Returns `True` if it is unique.
+    pub fn add(&mut self, items: Vec<String>) -> bool {
+        self.rminhash.update(items);
+        let digest = self.rminhash.digest();
+        self.rminhash.clear();
+        self.seen.insert(digest)
+    }
+}
+
+/// Inline deduplicator using `CMinHash`.
+#[pyclass(module = "rensa")]
+pub struct CMinHashDeduper {
+    num_perm: usize,
+    seed: u64,
+    #[pyo3(get)]
+    seen: HashSet<Vec<u32>>, 
+    cminhash: CMinHash,
+}
+
+#[pymethods]
+impl CMinHashDeduper {
+    #[new]
+    #[must_use]
+    pub fn new(num_perm: usize, seed: u64) -> Self {
+        Self {
+            num_perm,
+            seed,
+            seen: HashSet::new(),
+            cminhash: CMinHash::new(num_perm, seed),
+        }
+    }
+
+    /// Adds a new record. Returns `True` if it is unique.
+    pub fn add(&mut self, items: Vec<String>) -> bool {
+        self.cminhash.update(items);
+        let digest = self.cminhash.digest();
+        self.cminhash.clear();
+        self.seen.insert(digest)
+    }
+}
+
+/// Inline deduplicator using `OptDensMinHash`.
+#[pyclass(module = "rensa")]
+pub struct OptDensDeduper {
+    num_perm: usize,
+    seed: u64,
+    #[pyo3(get)]
+    seen: HashSet<Vec<u32>>, 
+    minhash: OptDensMinHash,
+}
+
+#[pymethods]
+impl OptDensDeduper {
+    #[new]
+    #[must_use]
+    pub fn new(num_perm: usize, seed: u64) -> Self {
+        Self {
+            num_perm,
+            seed,
+            seen: HashSet::new(),
+            minhash: OptDensMinHash::new(num_perm, seed),
+        }
+    }
+
+    /// Adds a new record. Returns `True` if it is unique.
+    pub fn add(&mut self, items: Vec<String>) -> bool {
+        self.minhash.update(items);
+        let digest = self.minhash.digest();
+        self.minhash.clear();
+        self.seen.insert(digest)
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,10 @@ mod lsh;
 mod opt_dens_minhash;
 mod rminhash;
 mod utils;
+mod dedup;
 
 pub use cminhash::CMinHash;
+pub use dedup::{CMinHashDeduper, OptDensDeduper, RMinHashDeduper};
 pub use lsh::RMinHashLSH;
 pub use opt_dens_minhash::OptDensMinHash;
 pub use rminhash::RMinHash;
@@ -28,5 +30,8 @@ pub fn rensa(m: &Bound<'_, PyModule>) -> PyResult<()> {
   m.add_class::<OptDensMinHash>()?;
   m.add_class::<CMinHash>()?;
   m.add_class::<RMinHashLSH>()?;
+  m.add_class::<RMinHashDeduper>()?;
+  m.add_class::<CMinHashDeduper>()?;
+  m.add_class::<OptDensDeduper>()?;
   Ok(())
 }

--- a/src/opt_dens_minhash.rs
+++ b/src/opt_dens_minhash.rs
@@ -88,6 +88,14 @@ impl OptDensMinHash {
     self.values.clone()
   }
 
+  /// Resets the internal state so the object can be reused for new data.
+  pub fn clear(&mut self) {
+    self.hsketch.fill(f64::MAX);
+    self.values.fill(u64::MAX);
+    self.init.fill(false);
+    self.nb_empty = i64::try_from(self.num_perm).unwrap_or(i64::MAX);
+  }
+
   pub fn jaccard(&mut self, other: &mut Self) -> f64 {
     self.end_sketch();
     other.end_sketch();

--- a/src/rminhash.rs
+++ b/src/rminhash.rs
@@ -138,6 +138,11 @@ impl RMinHash {
     self.hash_values.clone()
   }
 
+  /// Resets the internal state so the object can be reused for new data.
+  pub fn clear(&mut self) {
+    self.hash_values.fill(u32::MAX);
+  }
+
   /// Calculates the Jaccard similarity between this MinHash and another.
   ///
   /// # Arguments

--- a/tests/test_rensa.py
+++ b/tests/test_rensa.py
@@ -1,4 +1,12 @@
-from rensa import RMinHash, RMinHashLSH
+from rensa import (
+    RMinHash,
+    RMinHashLSH,
+    CMinHash,
+    OptDensMinHash,
+    RMinHashDeduper,
+    CMinHashDeduper,
+    OptDensDeduper,
+)
 
 
 def test_rminhash_creation():
@@ -83,3 +91,24 @@ def test_rminhashlsh_is_similar():
     jaccard_value = m1.jaccard(m2)
     assert lsh.is_similar(m1, m2) == (
         jaccard_value >= 0.8), "Check LSH threshold vs real jaccard"
+
+
+def test_inline_dedup_rminhash():
+    d = RMinHashDeduper(num_perm=8, seed=1)
+    assert d.add(["foo", "bar"])
+    assert not d.add(["foo", "bar"])
+    assert d.add(["bar", "baz"])
+
+
+def test_inline_dedup_cminhash():
+    d = CMinHashDeduper(num_perm=8, seed=2)
+    assert d.add(["foo"])
+    assert not d.add(["foo"])
+    assert d.add(["bar"])
+
+
+def test_inline_dedup_optdens():
+    d = OptDensDeduper(num_perm=8, seed=3)
+    assert d.add(["foo", "baz"])
+    assert not d.add(["foo", "baz"])
+    assert d.add(["baz", "qux"])


### PR DESCRIPTION
## Summary
- implement `*Deduper` classes for inline deduplication
- add `clear` methods to hashing structs
- expose dedupers in the Python module
- test new functionality
- document streaming usage

## Testing
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452a81378483329aac1dd34b74cda2