### PR TITLE
feat(dedup): implement inline deduplication

### DIFF
--- a/src/cminhash.rs
+++ b/src/cminhash.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 
 /// CMinHash implements an optimized version of C-MinHash with better memory access patterns
 /// and aggressive optimizations for maximum single-threaded performance.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[pyclass(module = "rensa")]
 pub struct CMinHash {
   num_perm: usize,

--- a/src/inline_dedup.rs
+++ b/src/inline_dedup.rs
@@ -1,0 +1,268 @@
+//! Inline deduplication support for continuous duplicate detection.
+//!
+//! This module provides functionality to check new records against an existing
+//! dataset for duplicates in real-time, supporting all `MinHash` variants.
+
+use crate::cminhash::CMinHash;
+use crate::lsh::RMinHashLSH;
+use crate::rminhash::RMinHash;
+use pyo3::prelude::*;
+use rustc_hash::FxHashMap;
+
+#[pyclass(module = "rensa")]
+pub struct RMinHashDeduplicator {
+  threshold: f64,
+  existing_signatures: FxHashMap<String, RMinHash>,
+  lsh_index: Option<RMinHashLSH>,
+  use_lsh: bool,
+  next_id: usize,
+  id_to_key: FxHashMap<usize, String>,
+}
+
+#[pymethods]
+impl RMinHashDeduplicator {
+  #[new]
+  #[pyo3(signature = (threshold, num_perm, use_lsh, num_bands=None))]
+  #[must_use]
+  pub fn new(
+    threshold: f64,
+    num_perm: usize,
+    use_lsh: bool,
+    num_bands: Option<usize>,
+  ) -> Self {
+    let lsh_index = if use_lsh {
+      let default_bands = if threshold >= 0.9 {
+        4
+      } else if threshold >= 0.8 {
+        8
+      } else if threshold >= 0.7 {
+        16
+      } else if threshold >= 0.5 {
+        32
+      } else {
+        num_perm / 2
+      };
+      let bands = num_bands.unwrap_or(default_bands);
+
+      let bands = if num_perm % bands == 0 {
+        bands
+      } else {
+        (1..=num_perm)
+          .rev()
+          .find(|&b| num_perm % b == 0 && b <= bands)
+          .unwrap_or(1)
+      };
+
+      Some(RMinHashLSH::new(threshold, num_perm, bands))
+    } else {
+      None
+    };
+
+    Self {
+      threshold,
+      existing_signatures: FxHashMap::default(),
+      lsh_index,
+      use_lsh,
+      next_id: 0,
+      id_to_key: FxHashMap::default(),
+    }
+  }
+
+  /// Add a new item to the deduplicator. Returns true if added (not a duplicate), false if duplicate.
+  pub fn add(&mut self, key: String, minhash: &RMinHash) -> bool {
+    if self.is_duplicate(&key, minhash) {
+      return false;
+    }
+
+    // Add to collection
+    self
+      .existing_signatures
+      .insert(key.clone(), minhash.clone());
+
+    // Add to LSH index if enabled
+    if let Some(ref mut lsh) = self.lsh_index {
+      lsh.insert(self.next_id, minhash);
+      self.id_to_key.insert(self.next_id, key);
+      self.next_id += 1;
+    }
+
+    true
+  }
+
+  /// Check if an item is a duplicate without adding it
+  #[must_use]
+  pub fn is_duplicate(&self, key: &str, minhash: &RMinHash) -> bool {
+    if self.existing_signatures.contains_key(key) {
+      return true;
+    }
+
+    if self.use_lsh {
+      // Use LSH for efficient similarity search
+      if let Some(ref lsh) = self.lsh_index {
+        let candidates = lsh.query(minhash);
+        for candidate_id in candidates {
+          if let Some(candidate_key) = self.id_to_key.get(&candidate_id) {
+            if let Some(candidate_minhash) =
+              self.existing_signatures.get(candidate_key)
+            {
+              if minhash.jaccard(candidate_minhash) >= self.threshold {
+                return true;
+              }
+            }
+          }
+        }
+      }
+    } else {
+      // Check all existing signatures
+      for existing_minhash in self.existing_signatures.values() {
+        if minhash.jaccard(existing_minhash) >= self.threshold {
+          return true;
+        }
+      }
+    }
+
+    false
+  }
+
+  /// Get duplicate candidates for a given MinHash
+  #[must_use]
+  pub fn get_duplicates(&self, minhash: &RMinHash) -> Vec<String> {
+    let mut duplicates = Vec::new();
+
+    if self.use_lsh {
+      if let Some(ref lsh) = self.lsh_index {
+        let candidates = lsh.query(minhash);
+        for candidate_id in candidates {
+          if let Some(candidate_key) = self.id_to_key.get(&candidate_id) {
+            if let Some(candidate_minhash) =
+              self.existing_signatures.get(candidate_key)
+            {
+              if minhash.jaccard(candidate_minhash) >= self.threshold {
+                duplicates.push(candidate_key.clone());
+              }
+            }
+          }
+        }
+      }
+    } else {
+      for (key, existing_minhash) in &self.existing_signatures {
+        if minhash.jaccard(existing_minhash) >= self.threshold {
+          duplicates.push(key.clone());
+        }
+      }
+    }
+
+    duplicates
+  }
+
+  /// Remove an item from the deduplicator
+  pub fn remove(&mut self, key: &str) -> bool {
+    self.existing_signatures.remove(key).is_some()
+  }
+
+  /// Get the number of items in the deduplicator
+  #[must_use]
+  pub fn len(&self) -> usize {
+    self.existing_signatures.len()
+  }
+
+  /// Check if the deduplicator is empty
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    self.existing_signatures.is_empty()
+  }
+
+  /// Clear all items from the deduplicator
+  pub fn clear(&mut self) {
+    self.existing_signatures.clear();
+    self.id_to_key.clear();
+    self.next_id = 0;
+    if let Some(ref mut lsh) = self.lsh_index {
+      // Recreate LSH index
+      let threshold = self.threshold;
+      let num_perm = lsh.get_num_perm();
+      let num_bands = lsh.get_num_bands();
+      self.lsh_index = Some(RMinHashLSH::new(threshold, num_perm, num_bands));
+    }
+  }
+}
+
+/// InlineDeduplicator for CMinHash
+#[pyclass(module = "rensa")]
+pub struct CMinHashDeduplicator {
+  threshold: f64,
+  existing_signatures: FxHashMap<String, CMinHash>,
+  signature_cache: FxHashMap<String, Vec<u64>>,
+}
+
+#[pymethods]
+impl CMinHashDeduplicator {
+  #[new]
+  #[must_use]
+  pub fn new(threshold: f64) -> Self {
+    Self {
+      threshold,
+      existing_signatures: FxHashMap::default(),
+      signature_cache: FxHashMap::default(),
+    }
+  }
+
+  pub fn add(&mut self, key: String, minhash: &CMinHash) -> bool {
+    if self.is_duplicate(&key, minhash) {
+      return false;
+    }
+
+    let signature = minhash.digest_u64();
+    self.signature_cache.insert(key.clone(), signature);
+    self.existing_signatures.insert(key, minhash.clone());
+    true
+  }
+
+  #[must_use]
+  pub fn is_duplicate(&self, key: &str, minhash: &CMinHash) -> bool {
+    if self.existing_signatures.contains_key(key) {
+      return true;
+    }
+
+    for existing_minhash in self.existing_signatures.values() {
+      if minhash.jaccard(existing_minhash) >= self.threshold {
+        return true;
+      }
+    }
+
+    false
+  }
+
+  #[must_use]
+  pub fn get_duplicates(&self, minhash: &CMinHash) -> Vec<String> {
+    let mut duplicates = Vec::new();
+
+    for (key, existing_minhash) in &self.existing_signatures {
+      if minhash.jaccard(existing_minhash) >= self.threshold {
+        duplicates.push(key.clone());
+      }
+    }
+
+    duplicates
+  }
+
+  pub fn remove(&mut self, key: &str) -> bool {
+    self.signature_cache.remove(key);
+    self.existing_signatures.remove(key).is_some()
+  }
+
+  #[must_use]
+  pub fn len(&self) -> usize {
+    self.existing_signatures.len()
+  }
+
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    self.existing_signatures.is_empty()
+  }
+
+  pub fn clear(&mut self) {
+    self.existing_signatures.clear();
+    self.signature_cache.clear();
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,15 @@
 #![allow(clippy::needless_pass_by_value)]
 
 mod cminhash;
+mod inline_dedup;
 mod lsh;
 mod opt_dens_minhash;
 mod rminhash;
 mod utils;
 
 pub use cminhash::CMinHash;
+pub use inline_dedup::CMinHashDeduplicator;
+pub use inline_dedup::RMinHashDeduplicator;
 pub use lsh::RMinHashLSH;
 pub use opt_dens_minhash::OptDensMinHash;
 pub use rminhash::RMinHash;
@@ -28,5 +31,7 @@ pub fn rensa(m: &Bound<'_, PyModule>) -> PyResult<()> {
   m.add_class::<OptDensMinHash>()?;
   m.add_class::<CMinHash>()?;
   m.add_class::<RMinHashLSH>()?;
+  m.add_class::<RMinHashDeduplicator>()?;
+  m.add_class::<CMinHashDeduplicator>()?;
   Ok(())
 }

--- a/src/lsh.rs
+++ b/src/lsh.rs
@@ -85,8 +85,21 @@ impl RMinHashLSH {
   ///
   /// * `key` - A unique identifier for the MinHash.
   /// * `minhash` - The RMinHash instance to be inserted.
+  ///
+  /// # Panics
+  ///
+  /// Panics if the MinHash has a different number of permutations than expected by the LSH index.
   pub fn insert(&mut self, key: usize, minhash: &RMinHash) {
     let digest = minhash.digest();
+
+    assert_eq!(
+      digest.len(),
+      self.num_perm,
+      "MinHash has {} permutations but LSH expects {}",
+      digest.len(),
+      self.num_perm
+    );
+
     for (i, table) in self.hash_tables.iter_mut().enumerate() {
       let start = i * self.band_size;
       let end = start + self.band_size;
@@ -104,9 +117,22 @@ impl RMinHashLSH {
   /// # Returns
   ///
   /// A vector of keys (usize) of potentially similar items.
+  ///
+  /// # Panics
+  ///
+  /// Panics if the MinHash has a different number of permutations than expected by the LSH index.
   #[must_use]
   pub fn query(&self, minhash: &RMinHash) -> Vec<usize> {
     let digest = minhash.digest();
+
+    assert_eq!(
+      digest.len(),
+      self.num_perm,
+      "MinHash has {} permutations but LSH expects {}",
+      digest.len(),
+      self.num_perm
+    );
+
     let mut candidates = Vec::new();
     for (i, table) in self.hash_tables.iter().enumerate() {
       let start = i * self.band_size;

--- a/src/rminhash.rs
+++ b/src/rminhash.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 const PERM_CHUNK_SIZE: usize = 16;
 
 /// RMinHash implements the MinHash algorithm for efficient similarity estimation.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[pyclass(module = "rensa")]
 pub struct RMinHash {
   num_perm: usize,

--- a/tests/test_inline_dedup.py
+++ b/tests/test_inline_dedup.py
@@ -1,0 +1,173 @@
+from rensa import CMinHash, CMinHashDeduplicator, RMinHash, RMinHashDeduplicator
+
+
+class TestInlineDeduplication:
+    def test_rminhash_deduplicator_basic(self):
+        """
+        GIVEN: A deduplicator with threshold 0.7
+        WHEN: Adding documents with varying similarity
+        THEN: Duplicates are detected and unique documents are stored
+        """
+        dedup = RMinHashDeduplicator(threshold=0.7, num_perm=128, use_lsh=False)
+
+        # GIVEN: First document MinHash
+        m1 = RMinHash(num_perm=128, seed=42)
+        m1.update(["hello", "world", "this", "is", "a", "test"])
+
+        # WHEN: Adding first document
+        # THEN: Should succeed
+        assert dedup.add("doc1", m1) is True
+        assert dedup.len() == 1
+
+        # WHEN: Adding same document again
+        # THEN: Should fail
+        assert dedup.add("doc1", m1) is False
+        assert dedup.len() == 1
+
+        # GIVEN: Similar document
+        m2 = RMinHash(num_perm=128, seed=42)
+        m2.update(
+            ["hello", "world", "this", "is", "a", "test", "slightly", "different"]
+        )
+
+        # WHEN: Checking if it's detected as duplicate
+        # THEN: Should be marked as duplicate
+        is_dup = dedup.is_duplicate("doc2", m2)
+        assert is_dup is True
+
+        # GIVEN: Very different document
+        m3 = RMinHash(num_perm=128, seed=42)
+        m3.update(["completely", "different", "content", "here"])
+
+        # WHEN: Adding different document
+        # THEN: Should not be duplicate and should be added
+        assert dedup.add("doc3", m3) is True
+        assert dedup.len() == 2
+
+    def test_rminhash_deduplicator_with_lsh(self):
+        """
+        GIVEN: A deduplicator with LSH enabled and threshold 0.8
+        WHEN: Adding multiple documents with varying similarity
+        THEN: Only unique documents are stored based on similarity threshold
+        """
+        dedup = RMinHashDeduplicator(
+            threshold=0.8, num_perm=128, use_lsh=True, num_bands=16
+        )
+
+        # GIVEN: Multiple documents with varying similarity
+        docs = [
+            ("doc1", ["hello", "world", "test"]),
+            ("doc2", ["hello", "world", "test", "again"]),  # Similar to doc1
+            ("doc3", ["completely", "different", "content"]),
+            ("doc4", ["hello", "world", "test"]),  # Duplicate of doc1
+        ]
+
+        # WHEN: Adding all documents
+        added_count = 0
+        for key, words in docs:
+            m = RMinHash(num_perm=128, seed=42)
+            m.update(words)
+            if dedup.add(key, m):
+                added_count += 1
+
+        # THEN: Should have added 2 or 3 documents (depending on similarity threshold)
+        assert added_count >= 2
+        assert added_count <= 3
+
+    def test_cminhash_deduplicator(self):
+        """
+        GIVEN: A CMinHash deduplicator with threshold 0.8
+        WHEN: Adding identical documents
+        THEN: Duplicates are correctly identified and can be retrieved
+        """
+        dedup = CMinHashDeduplicator(threshold=0.8)
+
+        # GIVEN: First document MinHash
+        c1 = CMinHash(num_perm=128, seed=42)
+        c1.update(["hello", "world", "this", "is", "a", "test"])
+
+        # WHEN: Adding first document
+        # THEN: Should succeed
+        assert dedup.add("doc1", c1) is True
+
+        # GIVEN: Identical document
+        c2 = CMinHash(num_perm=128, seed=42)
+        c2.update(["hello", "world", "this", "is", "a", "test"])
+
+        # WHEN: Checking for duplicates
+        # THEN: Should be detected as duplicate
+        assert dedup.is_duplicate("doc2", c2) is True
+
+        # WHEN: Getting duplicates
+        # THEN: Should return the original document
+        duplicates = dedup.get_duplicates(c2)
+        assert "doc1" in duplicates
+
+    def test_deduplicator_operations(self):
+        """
+        GIVEN: A deduplicator with unique documents
+        WHEN: Performing various operations (add, remove, clear)
+        THEN: Operations work correctly and maintain proper state
+        """
+        dedup = RMinHashDeduplicator(threshold=0.8, num_perm=64, use_lsh=False)
+
+        # GIVEN: Five unique documents
+        for i in range(5):
+            m = RMinHash(num_perm=64, seed=42)
+            # Each document has unique words based on its index
+            m.update([f"doc{i}_word{j}" for j in range(10)])
+            dedup.add(f"doc{i}", m)
+
+        # THEN: All documents should be added
+        assert dedup.len() == 5
+
+        # WHEN: Removing a document
+        # THEN: Should succeed and update count
+        assert dedup.remove("doc2") is True
+        assert dedup.len() == 4
+
+        # WHEN: Removing same document again
+        # THEN: Should fail
+        assert dedup.remove("doc2") is False  # Already removed
+
+        # WHEN: Clearing all documents
+        # THEN: Should be empty
+        dedup.clear()
+        assert dedup.len() == 0
+
+    def test_continuous_stream_simulation(self):
+        """
+        GIVEN: A stream of documents with some duplicates and similar content
+        WHEN: Processing documents through deduplicator
+        THEN: Duplicates are filtered out and unique documents are preserved
+        """
+        dedup = RMinHashDeduplicator(
+            threshold=0.7, num_perm=128, use_lsh=True, num_bands=16
+        )
+
+        # GIVEN: Document stream with duplicates and similar content
+        stream = [
+            "The quick brown fox jumps over the lazy dog",
+            "The quick brown fox jumps over the lazy cat",  # Similar
+            "Lorem ipsum dolor sit amet consectetur",
+            "The quick brown fox jumps over the lazy dog",  # Exact duplicate
+            "Lorem ipsum dolor sit amet consectetur adipiscing",  # Similar
+            "Completely different content here",
+        ]
+
+        # WHEN: Processing the document stream
+        unique_docs = []
+        duplicate_count = 0
+
+        for idx, text in enumerate(stream):
+            m = RMinHash(num_perm=128, seed=42)
+            m.update(text.split())
+
+            if dedup.add(f"doc{idx}", m):
+                unique_docs.append(text)
+            else:
+                duplicate_count += 1
+
+        # THEN: Should filter out duplicates
+        assert duplicate_count >= 1  # At least the exact duplicate
+        assert len(unique_docs) < len(stream)


### PR DESCRIPTION
# Add Inline Deduplication Support for Streaming Data

## Overview
This PR introduces inline deduplication functionality to Rensa, enabling real-time duplicate detection for streaming data scenarios. Users can now check new records against existing datasets as they arrive, perfect for continuous data processing pipelines.

## Key Features Added

### New Deduplicator Classes
- **`RMinHashDeduplicator`**: LSH-enabled deduplicator for high-performance similarity detection
- **`CMinHashDeduplicator`**: Simple deduplicator for smaller datasets

### Core API Methods
```python
# Add items and check duplicates in real-time
deduplicator.add(key, minhash) -> bool
deduplicator.is_duplicate(key, minhash) -> bool
deduplicator.get_duplicates(minhash) -> List[str]
deduplicator.remove(key) -> bool
deduplicator.len() -> int
deduplicator.clear()
```


## Usage Example
```python
from rensa import RMinHashDeduplicator, RMinHash

# Initialize for streaming data
deduplicator = RMinHashDeduplicator(
    threshold=0.7,
    num_perm=128,
    use_lsh=True,
    num_bands=32
)

# Process streaming records
for record in data_stream:
    minhash = RMinHash(num_perm=128)
    minhash.update(record.text.split())
    
    if not deduplicator.is_duplicate(record.id, minhash):
        deduplicator.add(record.id, minhash)
        # Process unique record
```