### PR TITLE
feat(mimalloc): use mimalloc as memory allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,12 +86,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -237,6 +265,7 @@ name = "rensa"
 version = "0.2.4"
 dependencies = [
  "bincode",
+ "mimalloc",
  "murmur3",
  "pyo3",
  "rand",
@@ -271,6 +300,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 murmur3 = "0.5.2"
 rand_xoshiro = "0.7.0"
 rand_chacha = "0.9.0"
+mimalloc = "*"
 
 [profile.release]
 lto = "fat"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,11 @@
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::needless_pass_by_value)]
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 mod cminhash;
 mod inline_dedup;
 mod lsh;


### PR DESCRIPTION
## Add MiMalloc as Global Memory Allocator

Replaces the default system allocator with Microsoft's MiMalloc for improved memory allocation performance.

### Changes
- Added `mimalloc` dependency to `Cargo.toml`
- Set MiMalloc as the global allocator in `src/lib.rs`

### Benefits
- Better allocation performance, especially for workloads with frequent allocations/deallocations
- Reduced memory fragmentation
- Generally faster than system malloc implementations

### Impact
- Zero API changes - transparent performance improvement
- Minimal memory overhead
- Cross-platform compatibility maintained
