### PR TITLE
chore(release): bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "rensa"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "libmimalloc-sys",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rensa"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Luis Cardoso <luis@luiscardoso.dev>"]


### PR DESCRIPTION
## Summary

- bump the Rensa package version from 0.4.0 to 0.4.1
- keep the Cargo lockfile package metadata in sync

## Why

This patch release publishes the performance improvements and security dependency update merged in #84.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --benches --tests --examples --all-features -- -D clippy::pedantic -D clippy::nursery`
- `cargo test --all-features`
- `cargo deny check`
- release-mode maturin build/install
- Python test suite: 83 passed
- installed distribution metadata reports version 0.4.1