### PR TITLE
perf: accelerate full-set R-MinHash and correct C-MinHash

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -520,6 +520,12 @@ jobs:
                         f"base={baseline['median_seconds']:.6f}s, FastSketch={competitor['median_seconds']:.6f}s; "
                         f"{baseline['median_seconds'] / result['median_seconds']:.3f}x versus base, "
                         f"{competitor['median_seconds'] / result['median_seconds']:.3f}x versus FastSketch")
+                  if result["median_seconds"] > 1.05 * competitor["median_seconds"]:
+                      regression = f"FAIL: Native R-MinHash exceeds FastSketch by more than 5%: n={key[1]}, k={key[2]}"
+                      print(regression)
+                      native_regressions.append(regression)
+                  else:
+                      print(f"PASS: Native R-MinHash meets FastSketch speed gate (5% tolerance): n={key[1]}, k={key[2]}")
                   if result["median_seconds"] > 1.20 * baseline["median_seconds"]:
                       regression = f"Native R-MinHash exceeds 20% per-case slowdown: n={key[1]}, k={key[2]}"
                       if r_migration:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,13 +11,17 @@ on:
   workflow_dispatch:
     inputs:
       performance_only:
-        description: Run only strict performance comparisons against origin/main
+        description: Run only strict performance comparisons
         type: boolean
         default: false
       require_avx512:
         description: Fail before benchmarking if the runner lacks AVX-512F/DQ
         type: boolean
         default: false
+      baseline_sha:
+        description: Optional full ancestor commit SHA for a same-run performance comparison
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -285,11 +289,20 @@ jobs:
         shell: bash
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          REQUESTED_BASE_SHA: ${{ inputs.baseline_sha }}
         run: |
           set -euo pipefail
           if [ -n "${PR_BASE_SHA}" ]; then
             BASE_SHA="${PR_BASE_SHA}"
             git fetch --no-tags origin "${BASE_SHA}"
+          elif [ -n "${REQUESTED_BASE_SHA}" ]; then
+            if [[ ! "${REQUESTED_BASE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "baseline_sha must be a full 40-character commit SHA." >&2
+              exit 1
+            fi
+            BASE_SHA="${REQUESTED_BASE_SHA}"
+            git fetch --no-tags origin "${BASE_SHA}"
+            git merge-base --is-ancestor "${BASE_SHA}" HEAD
           else
             # Resolve main once, so a manual run compares both builds to one commit.
             git fetch --no-tags origin main

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -284,7 +284,9 @@ jobs:
             popd >/dev/null
 
             if [ "${label}" = "head" ]; then
-              "${BENCH_PY}" -m pytest -q "${GITHUB_WORKSPACE}/tests/test_accuracy.py"
+              "${BENCH_PY}" -m pytest -q \
+                "${GITHUB_WORKSPACE}/tests/test_accuracy.py" \
+                "${GITHUB_WORKSPACE}/tests/test_rensa.py"
             fi
 
             "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/simple_benchmark.py" \
@@ -311,9 +313,16 @@ jobs:
             "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/sketch_benchmark.py" \
               --engines rensa_classic fastsketch --rows 256 --repetitions 5 \
               --min-sample-seconds 0.1 \
-              --sizes 1 8 32 128 1024 4096 --num-perm 128 512 \
+              --sizes 1 8 32 128 1024 4096 16384 --num-perm 128 512 \
               --output-json "${output_json%.json}_sketches.json" \
               | tee "${output_log%.txt}_sketches.txt"
+
+            "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/sketch_benchmark.py" \
+              --prehashed --rows 256 --repetitions 5 --min-sample-seconds 0.05 \
+              --max-input-tokens 8388608 \
+              --sizes 0 1 8 128 4096 65536 1048576 --num-perm 128 512 \
+              --output-json "${output_json%.json}_prehashed.json" \
+              | tee "${output_log%.txt}_prehashed.txt"
 
             echo "Completed ${label} benchmark."
           }
@@ -483,63 +492,72 @@ jobs:
                       rmses.append(math.sqrt(sum(cell["count"] * cell["rmse"] ** 2 for cell in cells) / count))
                   check_rmse(f"k={k}, n={size}", *rmses, 1.20)
 
-          with open(".bench/head_sketches.json", encoding="utf-8") as handle:
-              head_sketches = json.load(handle)
-          with open(".bench/base_sketches.json", encoding="utf-8") as handle:
-              base_sketches = json.load(handle)
-          if head_sketches["config"] != base_sketches["config"] or head_sketches["environment"]["flags"] != base_sketches["environment"]["flags"]:
-              raise SystemExit("native sketch benchmark config/environment mismatch")
-          if head_sketches["config"]["repetitions"] < 5 or head_sketches["config"]["min_sample_seconds"] < 0.1:
-              raise SystemExit("native sketch performance gates require at least five 0.1-second samples")
-          sketch_versions = (base_sketches["environment"]["rminhash_algorithm_version"],
-                             head_sketches["environment"]["rminhash_algorithm_version"])
-          if sketch_versions != algorithm_versions["rminhash"]:
-              raise SystemExit("native sketch R-MinHash algorithm version mismatch")
-          native_cases = []
-          expected = {(engine, size, k) for engine in ("rensa_classic", "fastsketch")
-                      for size in (1, 8, 32, 128, 1024, 4096) for k in (128, 512)}
-          for payload in (head_sketches, base_sketches):
-              cases = {(result["engine"], result["tokens_per_row"], result["num_perm"]): result for result in payload["results"]}
-              if cases.keys() != expected or len(payload["results"]) != len(expected):
-                  raise SystemExit("native sketch benchmark cases mismatch or duplicates")
-              native_cases.append(cases)
-          native_log_ratios = []
-          native_regressions = []
-          for key, result in native_cases[0].items():
-              baseline = native_cases[1][key]
-              competitor = native_cases[0][("fastsketch", key[1], key[2])]
-              if len({result["input_sha256"], baseline["input_sha256"], competitor["input_sha256"]}) != 1:
-                  raise SystemExit(f"native sketch input mismatch: {key}")
-              if result["sha256"] != baseline["sha256"] and not (r_migration and key[0] == "rensa_classic"):
-                  raise SystemExit(f"native sketch output changed: {key}")
-              if not all(0 < item["median_seconds"] < float("inf") for item in (result, baseline, competitor)):
-                  raise SystemExit(f"invalid native sketch timing: {key}")
-              if key[0] == "rensa_classic":
-                  native_log_ratios.append(math.log(result["median_seconds"]) - math.log(baseline["median_seconds"]))
-                  print(f"Native R-MinHash n={key[1]}, k={key[2]}: head={result['median_seconds']:.6f}s, "
-                        f"base={baseline['median_seconds']:.6f}s, FastSketch={competitor['median_seconds']:.6f}s; "
-                        f"{baseline['median_seconds'] / result['median_seconds']:.3f}x versus base, "
-                        f"{competitor['median_seconds'] / result['median_seconds']:.3f}x versus FastSketch")
-                  if result["median_seconds"] > 1.05 * competitor["median_seconds"]:
-                      regression = f"FAIL: Native R-MinHash exceeds FastSketch by more than 5%: n={key[1]}, k={key[2]}"
-                      print(regression)
-                      native_regressions.append(regression)
-                  else:
-                      print(f"PASS: Native R-MinHash meets FastSketch speed gate (5% tolerance): n={key[1]}, k={key[2]}")
-                  if result["median_seconds"] > 1.20 * baseline["median_seconds"]:
-                      regression = f"Native R-MinHash exceeds 20% per-case slowdown: n={key[1]}, k={key[2]}"
-                      if r_migration:
-                          print(f"{regression}; v1->v2 family migration uses aggregate performance and accuracy gates")
-                      else:
+          sketch_regressions = []
+          for suite, sizes, min_sample in (
+              ("sketches", (1, 8, 32, 128, 1024, 4096, 16384), 0.1),
+              ("prehashed", (0, 1, 8, 128, 4096, 65536, 1048576), 0.05),
+          ):
+              print(f"Validating {suite} benchmark")
+              with open(f".bench/head_{suite}.json", encoding="utf-8") as handle:
+                  head_sketches = json.load(handle)
+              with open(f".bench/base_{suite}.json", encoding="utf-8") as handle:
+                  base_sketches = json.load(handle)
+              if head_sketches["config"] != base_sketches["config"] or head_sketches["environment"]["flags"] != base_sketches["environment"]["flags"]:
+                  raise SystemExit("native sketch benchmark config/environment mismatch")
+              if head_sketches["config"]["repetitions"] < 5 or head_sketches["config"]["min_sample_seconds"] < min_sample:
+                  raise SystemExit(f"{suite} gates require at least five {min_sample}-second samples")
+              if head_sketches["config"]["prehashed"] != (suite == "prehashed"):
+                  raise SystemExit(f"{suite} input mode mismatch")
+              sketch_versions = (base_sketches["environment"]["rminhash_algorithm_version"],
+                                 head_sketches["environment"]["rminhash_algorithm_version"])
+              if sketch_versions != algorithm_versions["rminhash"]:
+                  raise SystemExit("native sketch R-MinHash algorithm version mismatch")
+              native_cases = []
+              expected = {(engine, size, k) for engine in ("rensa_classic", "fastsketch")
+                          for size in sizes for k in (128, 512)}
+              for payload in (head_sketches, base_sketches):
+                  cases = {(result["engine"], result["tokens_per_row"], result["num_perm"]): result for result in payload["results"]}
+                  if cases.keys() != expected or len(payload["results"]) != len(expected):
+                      raise SystemExit("native sketch benchmark cases mismatch or duplicates")
+                  native_cases.append(cases)
+              native_log_ratios = []
+              native_regressions = []
+              for key, result in native_cases[0].items():
+                  baseline = native_cases[1][key]
+                  competitor = native_cases[0][("fastsketch", key[1], key[2])]
+                  if len({result["input_sha256"], baseline["input_sha256"], competitor["input_sha256"]}) != 1:
+                      raise SystemExit(f"native sketch input mismatch: {key}")
+                  if result["sha256"] != baseline["sha256"] and not (r_migration and key[0] == "rensa_classic"):
+                      raise SystemExit(f"native sketch output changed: {key}")
+                  if not all(0 < item["median_seconds"] < float("inf") for item in (result, baseline, competitor)):
+                      raise SystemExit(f"invalid native sketch timing: {key}")
+                  if key[0] == "rensa_classic":
+                      native_log_ratios.append(math.log(result["median_seconds"]) - math.log(baseline["median_seconds"]))
+                      print(f"{suite} R-MinHash n={key[1]}, k={key[2]}: head={result['median_seconds']:.6f}s, "
+                            f"base={baseline['median_seconds']:.6f}s, FastSketch={competitor['median_seconds']:.6f}s; "
+                            f"{baseline['median_seconds'] / result['median_seconds']:.3f}x versus base, "
+                            f"{competitor['median_seconds'] / result['median_seconds']:.3f}x versus FastSketch")
+                      if result["median_seconds"] > 1.05 * competitor["median_seconds"]:
+                          regression = f"FAIL: Native R-MinHash exceeds FastSketch by more than 5%: n={key[1]}, k={key[2]}"
+                          print(regression)
                           native_regressions.append(regression)
-          # Equal weight per size/width prevents long cases from dominating.
-          native_mean_log_ratio = sum(native_log_ratios) / len(native_log_ratios)
-          if native_mean_log_ratio > math.log(1.10):
-              native_regressions.append("Native R-MinHash geometric-mean slowdown exceeds 10%")
-          print(f"Native R-MinHash geometric-mean slowdown across {len(native_log_ratios)} cases: "
-                f"{math.expm1(native_mean_log_ratio):.2%}; maximum allowed: 10%")
-          if native_regressions:
-              raise SystemExit("\n".join(native_regressions))
+                      else:
+                          print(f"PASS: Native R-MinHash meets FastSketch speed gate (5% tolerance): n={key[1]}, k={key[2]}")
+                      if result["median_seconds"] > 1.20 * baseline["median_seconds"]:
+                          regression = f"Native R-MinHash exceeds 20% per-case slowdown: n={key[1]}, k={key[2]}"
+                          if r_migration:
+                              print(f"{regression}; v1->v2 family migration uses aggregate performance and accuracy gates")
+                          else:
+                              native_regressions.append(regression)
+              # Equal weight per size/width prevents long cases from dominating.
+              native_mean_log_ratio = sum(native_log_ratios) / len(native_log_ratios)
+              if native_mean_log_ratio > math.log(1.10):
+                  native_regressions.append("Native R-MinHash geometric-mean slowdown exceeds 10%")
+              print(f"{suite} R-MinHash geometric-mean slowdown across {len(native_log_ratios)} cases: "
+                    f"{math.expm1(native_mean_log_ratio):.2%}; maximum allowed: 10%")
+              sketch_regressions.extend(f"{suite}: {failure}" for failure in native_regressions)
+          if sketch_regressions:
+              raise SystemExit("\n".join(sketch_regressions))
           PY
 
       - name: Run full benchmark smoke
@@ -579,7 +597,7 @@ jobs:
 
           VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" PATH="${GITHUB_WORKSPACE}/.venv/bin:${PATH}" .venv/bin/maturin develop --release
 
-          .venv/bin/python -m pytest -q tests/test_accuracy.py
+          .venv/bin/python -m pytest -q tests/test_accuracy.py tests/test_rensa.py
           .venv/bin/python benchmarks/accuracy_benchmark.py \
             --seeds 8 --skip-retrieval \
             --output-json .bench/head_accuracy.json \
@@ -588,9 +606,16 @@ jobs:
           .venv/bin/python benchmarks/sketch_benchmark.py \
             --engines rensa_classic fastsketch --rows 256 --repetitions 5 \
             --min-sample-seconds 0.1 \
-            --sizes 1 8 32 128 1024 4096 --num-perm 128 512 \
+            --sizes 1 8 32 128 1024 4096 16384 --num-perm 128 512 \
             --output-json .bench/head_sketches.json \
             | tee .bench/head_sketches.txt
+
+          .venv/bin/python benchmarks/sketch_benchmark.py \
+            --prehashed --rows 256 --repetitions 5 --min-sample-seconds 0.05 \
+            --max-input-tokens 8388608 \
+            --sizes 0 1 8 128 4096 65536 1048576 --num-perm 128 512 \
+            --output-json .bench/head_prehashed.json \
+            | tee .bench/head_prehashed.txt
 
           .venv/bin/python benchmarks/simple_benchmark.py \
             --dataset "${BENCH_DATASET_KEY}" \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -242,6 +242,7 @@ jobs:
       HF_HOME: ${{ github.workspace }}/.hf-cache
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       BENCH_COMPARE: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.performance_only) }}
+      BENCH_PAIRED: ${{ github.event_name == 'workflow_dispatch' && inputs.performance_only && inputs.baseline_sha != '' }}
       BENCH_DATASET_KEY: ag_news
       BENCH_MAX_ROWS: "10000"
       BENCH_FULL_SMOKE_MAX_ROWS: "2000"
@@ -345,6 +346,20 @@ jobs:
             VIRTUAL_ENV="${BENCH_VENV}" PATH="${BENCH_VENV}/bin:${PATH}" "${BENCH_MATURIN}" develop --release
             popd >/dev/null
 
+            if [ "${BENCH_PAIRED}" = "true" ]; then
+              "${BENCH_PY}" - "${GITHUB_WORKSPACE}/.bench/${label}-native/rensa.so" <<'PY'
+          import importlib
+          from pathlib import Path
+          import shutil
+          import sys
+
+          source = Path(importlib.import_module("rensa.rensa").__file__)
+          destination = Path(sys.argv[1])
+          destination.parent.mkdir(parents=True, exist_ok=True)
+          shutil.copy2(source, destination)
+          PY
+            fi
+
             if [ "${label}" = "head" ]; then
               if grep -qw avx512f /proc/cpuinfo && grep -qw avx512dq /proc/cpuinfo; then
                 export RENSA_REQUIRE_AVX512=1
@@ -429,6 +444,67 @@ jobs:
             "${GITHUB_WORKSPACE}/.bench/base.json" \
             "${GITHUB_WORKSPACE}/.bench/base_summary.txt" \
             "base"
+
+      - name: Compare frozen builds in alternating pairs
+        if: env.BENCH_PAIRED == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -qw avx512f /proc/cpuinfo && grep -qw avx512dq /proc/cpuinfo; then
+            export RENSA_REQUIRE_AVX512=1
+          fi
+          PAIRED_FAMILY="$("${GITHUB_WORKSPACE}/.venv/bin/python" - <<'PY'
+          import json
+          from pathlib import Path
+
+          versions = [json.loads(Path(f".bench/{label}_kernels.json").read_text())
+                      ["environment"]["rminhash_algorithm_version"]
+                      for label in ("base", "head")]
+          print("same" if versions[0] == versions[1] else "migration")
+          PY
+          )"
+          if [ "${PAIRED_FAMILY}" = "migration" ]; then
+            echo "Paired signature-identity diagnostic skipped for algorithm migration." | tee .bench/paired_skip.txt
+            exit 0
+          fi
+          "${GITHUB_WORKSPACE}/.venv/bin/python" benchmarks/paired_sketch_benchmark.py \
+            --base-extension .bench/base-native/rensa.so \
+            --head-extension .bench/head-native/rensa.so \
+            --prehashed --rows 256 --max-input-tokens 8388608 \
+            --sizes 0 1 8 128 4096 65536 1048576 --num-perm 128 512 \
+            --repetitions 6 --min-sample-seconds 0.1 --warmup-seconds 0.2 \
+            --output-json .bench/paired_prehashed.json | tee .bench/paired_prehashed.txt
+          "${GITHUB_WORKSPACE}/.venv/bin/python" - <<'PY'
+          import json
+          from pathlib import Path
+
+          paired = json.loads(Path(".bench/paired_prehashed.json").read_text())
+          cases = {(row["tokens_per_row"], row["num_perm"]): row for row in paired["results"]}
+          if len(cases) != len(paired["results"]):
+              raise SystemExit("Duplicate paired benchmark cases")
+          for label in ("base", "head"):
+              reference = json.loads(Path(f".bench/{label}_prehashed.json").read_text())
+              environment = reference["environment"]
+              for key in ("cpu_flags", "flags"):
+                  if paired["environment"][key] != environment[key]:
+                      raise SystemExit(f"Paired {label} environment mismatch: {key}")
+              if paired["environment"]["fastsketch_binary_sha256"] != environment["native_binary_sha256"]["FastSketchLSH"]:
+                  raise SystemExit(f"Paired {label} FastSketch binary differs")
+              if paired["extensions"][label]["sha256"] not in environment["native_binary_sha256"]["rensa"].values():
+                  raise SystemExit(f"Frozen {label} binary differs from the measured build")
+              if paired["extensions"][label]["algorithm_version"] != environment["rminhash_algorithm_version"]:
+                  raise SystemExit(f"Frozen {label} algorithm version differs from the measured build")
+              for engine, sample in (("rensa_classic", label), ("fastsketch", "fastsketch")):
+                  expected = {(row["tokens_per_row"], row["num_perm"]): row
+                              for row in reference["results"] if row["engine"] == engine}
+                  if cases.keys() != expected.keys():
+                      raise SystemExit(f"Paired {label}/{engine} case matrix mismatch")
+                  for key, row in cases.items():
+                      if (row["input_sha256"] != expected[key]["input_sha256"]
+                              or row["samples"][sample]["sha256"] != expected[key]["sha256"]):
+                          raise SystemExit(f"Paired {label}/{engine} fingerprint mismatch: {key}")
+          print("Paired diagnostic matches both frozen builds and every reference fingerprint.")
+          PY
 
       - name: Validate repeated-token backend diagnostics
         if: env.BENCH_COMPARE == 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           python-version: "3.9"
       - name: Run Rust tests
-        run: cargo test --locked
+        run: |
+          lscpu
+          cargo test --locked
       - name: Lint with clippy
         run: cargo clippy --locked --all --benches --tests --examples --all-features -- -D warnings -D clippy::pedantic -D clippy::nursery
 
@@ -487,6 +489,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: performance-check-artifacts
+          include-hidden-files: true
           path: |
             .bench/*.json
             .bench/*.txt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -298,7 +298,7 @@ jobs:
               --output-json "${output_json}" \
               | tee "${output_log}"
 
-            RAYON_NUM_THREADS=1 "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/kernel_benchmark.py" \
+            RAYON_NUM_THREADS=1 RENSA_PIPELINE_QUEUE_CAP=0 "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/kernel_benchmark.py" \
               --rows 256 --repetitions 5 --sizes 1 8 32 128 4096 --num-perm 128 512 \
               --output-json "${output_json%.json}_kernels.json" \
               | tee "${output_log%.txt}_kernels.txt"
@@ -307,6 +307,13 @@ jobs:
               --seeds 8 --skip-retrieval \
               --output-json "${output_json%.json}_accuracy.json" \
               | tee "${output_log%.txt}_accuracy.txt"
+
+            "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/sketch_benchmark.py" \
+              --engines rensa_classic fastsketch --rows 256 --repetitions 5 \
+              --min-sample-seconds 0.1 \
+              --sizes 1 8 32 128 1024 4096 --num-perm 128 512 \
+              --output-json "${output_json%.json}_sketches.json" \
+              | tee "${output_log%.txt}_sketches.txt"
 
             echo "Completed ${label} benchmark."
           }
@@ -330,6 +337,7 @@ jobs:
           set -euo pipefail
           "${GITHUB_WORKSPACE}/.venv/bin/python" - <<'PY' | tee .bench/validation_pr.txt
           import json
+          import math
 
           with open(".bench/head.json", "r", encoding="utf-8") as handle:
               head = json.load(handle)
@@ -352,15 +360,19 @@ jobs:
               if head["config"][key] != base["config"][key]:
                   raise SystemExit(f"benchmark input/config mismatch: {key}")
 
-          c_versions = (base["metadata"]["cminhash_algorithm_version"],
-                        head["metadata"]["cminhash_algorithm_version"])
-          # The bias correction changes C signatures once, from version 1 to 2.
-          # Same-version comparisons retain every output check.
-          c_migration = c_versions == (1, 2)
-          if c_versions[0] != c_versions[1] and not c_migration:
-              raise SystemExit(f"unsupported C-MinHash algorithm transition: {c_versions}")
-          if c_migration:
-              print("C-MinHash 1->2 correction: compare accuracy artifacts; require per-build determinism")
+          # The reviewed v2 algorithms change signatures once. Same-version
+          # comparisons retain every output check; rho keeps its own algorithm.
+          algorithm_versions = {}
+          for name in ("cminhash", "rminhash"):
+              versions = (base["metadata"][f"{name}_algorithm_version"],
+                          head["metadata"][f"{name}_algorithm_version"])
+              if versions[0] != versions[1] and versions != (1, 2):
+                  raise SystemExit(f"unsupported {name} algorithm transition: {versions}")
+              algorithm_versions[name] = versions
+              if versions == (1, 2):
+                  print(f"{name} 1->2 migration: compare accuracy artifacts; require per-build determinism")
+          c_migration = algorithm_versions["cminhash"] == (1, 2)
+          r_migration = algorithm_versions["rminhash"] == (1, 2)
 
           for engine in required_engines:
               flag_hashes = []
@@ -399,10 +411,11 @@ jobs:
               raise SystemExit("kernel benchmark config mismatch")
           if head_kernels["environment"]["flags"] != base_kernels["environment"]["flags"]:
               raise SystemExit("kernel benchmark environment flags mismatch")
-          kernel_c_versions = (base_kernels["environment"]["cminhash_algorithm_version"],
-                               head_kernels["environment"]["cminhash_algorithm_version"])
-          if kernel_c_versions != c_versions:
-              raise SystemExit("C-MinHash algorithm versions differ between benchmark suites")
+          for name, versions in algorithm_versions.items():
+              kernel_versions = (base_kernels["environment"][f"{name}_algorithm_version"],
+                                 head_kernels["environment"][f"{name}_algorithm_version"])
+              if kernel_versions != versions:
+                  raise SystemExit(f"{name} algorithm versions differ between benchmark suites")
           def keyed_results(payload):
               return {
                   (result["case"], result["tokens_per_row"], result["num_perm"]): result
@@ -415,13 +428,112 @@ jobs:
           for key, result in head_cases.items():
               baseline = base_cases[key]
               c_signature_migration = c_migration and key[0] in ("c_update", "c_prehashed")
-              if result["sha256"] != baseline["sha256"] and not c_signature_migration:
+              r_signature_migration = r_migration and key[0] in ("r_update", "r_batch", "r_prehashed")
+              if result["sha256"] != baseline["sha256"] and not (c_signature_migration or r_signature_migration):
                   raise SystemExit(f"kernel output changed: {key}")
               head_time, base_time = result["median_seconds"], baseline["median_seconds"]
               if not (0 < head_time < float("inf") and 0 < base_time < float("inf")):
                   raise SystemExit(f"invalid kernel timings: {key}")
-              output_check = "C-MinHash 1->2 signature correction" if c_signature_migration else "output unchanged"
+              output_check = (
+                  "C-MinHash 1->2 signature correction" if c_signature_migration else
+                  "R-MinHash 1->2 signature migration" if r_signature_migration else "output unchanged"
+              )
               print(f"Kernel {key}: {base_time / head_time:.3f}x speedup; {output_check}")
+
+          with open(".bench/head_accuracy.json", encoding="utf-8") as handle:
+              head_accuracy = json.load(handle)
+          with open(".bench/base_accuracy.json", encoding="utf-8") as handle:
+              base_accuracy = json.load(handle)
+          accuracy_config = lambda payload: {k: v for k, v in payload["config"].items() if k != "output_json"}
+          if accuracy_config(head_accuracy) != accuracy_config(base_accuracy):
+              raise SystemExit("accuracy benchmark config mismatch")
+          if head_accuracy["environment"] != base_accuracy["environment"]:
+              raise SystemExit("accuracy benchmark environment mismatch")
+          for name, versions in algorithm_versions.items():
+              if (base_accuracy[f"{name}_algorithm_version"], head_accuracy[f"{name}_algorithm_version"]) != versions:
+                  raise SystemExit(f"{name} accuracy benchmark algorithm version mismatch")
+
+          def check_rmse(label, head_rmse, base_rmse, factor):
+              if not all(math.isfinite(value) and value >= 0 for value in (head_rmse, base_rmse)):
+                  raise SystemExit(f"invalid RMSE: {label}")
+              # Fixed trials still sample different hash families after migration.
+              # Allow a small absolute margin as well as the relative tolerance.
+              limit = factor * base_rmse + 0.001
+              if head_rmse > limit:
+                  raise SystemExit(f"R-MinHash accuracy regression {label}: head={head_rmse:.6f}, base={base_rmse:.6f}, limit={limit:.6f}")
+              print(f"PASS: R-MinHash RMSE {label}: head={head_rmse:.6f}, base={base_rmse:.6f}, limit={limit:.6f}")
+
+          for k in head_accuracy["config"]["perms"]:
+              # Compare classic R against classic R and exact-set ground truth,
+              # never against the biased legacy C implementation.
+              current = head_accuracy["accuracy"][f"rensa_classic/k={k}"]
+              previous = base_accuracy["accuracy"][f"rensa_classic/k={k}"]
+              if current["count"] != previous["count"] or current["by_case"].keys() != previous["by_case"].keys():
+                  raise SystemExit("R-MinHash accuracy cases differ")
+              check_rmse(f"k={k}", current["rmse"], previous["rmse"], 1.10)
+              if not abs(current["bias"]) <= 0.005 or not 0 <= current["mse_over_ideal_minhash"] <= 1.25:
+                  raise SystemExit(f"R-MinHash bias or MSE exceeds exact-Jaccard guard: k={k}")
+              for size in head_accuracy["config"]["sizes"]:
+                  rmses = []
+                  for result in (current, previous):
+                      cells = [cell for case, cell in result["by_case"].items() if case.startswith(f"n={size},")]
+                      count = sum(cell["count"] for cell in cells)
+                      if not count:
+                          raise SystemExit(f"missing R-MinHash accuracy size: {size}")
+                      rmses.append(math.sqrt(sum(cell["count"] * cell["rmse"] ** 2 for cell in cells) / count))
+                  check_rmse(f"k={k}, n={size}", *rmses, 1.20)
+
+          with open(".bench/head_sketches.json", encoding="utf-8") as handle:
+              head_sketches = json.load(handle)
+          with open(".bench/base_sketches.json", encoding="utf-8") as handle:
+              base_sketches = json.load(handle)
+          if head_sketches["config"] != base_sketches["config"] or head_sketches["environment"]["flags"] != base_sketches["environment"]["flags"]:
+              raise SystemExit("native sketch benchmark config/environment mismatch")
+          if head_sketches["config"]["repetitions"] < 5 or head_sketches["config"]["min_sample_seconds"] < 0.1:
+              raise SystemExit("native sketch performance gates require at least five 0.1-second samples")
+          sketch_versions = (base_sketches["environment"]["rminhash_algorithm_version"],
+                             head_sketches["environment"]["rminhash_algorithm_version"])
+          if sketch_versions != algorithm_versions["rminhash"]:
+              raise SystemExit("native sketch R-MinHash algorithm version mismatch")
+          native_cases = []
+          expected = {(engine, size, k) for engine in ("rensa_classic", "fastsketch")
+                      for size in (1, 8, 32, 128, 1024, 4096) for k in (128, 512)}
+          for payload in (head_sketches, base_sketches):
+              cases = {(result["engine"], result["tokens_per_row"], result["num_perm"]): result for result in payload["results"]}
+              if cases.keys() != expected or len(payload["results"]) != len(expected):
+                  raise SystemExit("native sketch benchmark cases mismatch or duplicates")
+              native_cases.append(cases)
+          native_log_ratios = []
+          native_regressions = []
+          for key, result in native_cases[0].items():
+              baseline = native_cases[1][key]
+              competitor = native_cases[0][("fastsketch", key[1], key[2])]
+              if len({result["input_sha256"], baseline["input_sha256"], competitor["input_sha256"]}) != 1:
+                  raise SystemExit(f"native sketch input mismatch: {key}")
+              if result["sha256"] != baseline["sha256"] and not (r_migration and key[0] == "rensa_classic"):
+                  raise SystemExit(f"native sketch output changed: {key}")
+              if not all(0 < item["median_seconds"] < float("inf") for item in (result, baseline, competitor)):
+                  raise SystemExit(f"invalid native sketch timing: {key}")
+              if key[0] == "rensa_classic":
+                  native_log_ratios.append(math.log(result["median_seconds"]) - math.log(baseline["median_seconds"]))
+                  print(f"Native R-MinHash n={key[1]}, k={key[2]}: head={result['median_seconds']:.6f}s, "
+                        f"base={baseline['median_seconds']:.6f}s, FastSketch={competitor['median_seconds']:.6f}s; "
+                        f"{baseline['median_seconds'] / result['median_seconds']:.3f}x versus base, "
+                        f"{competitor['median_seconds'] / result['median_seconds']:.3f}x versus FastSketch")
+                  if result["median_seconds"] > 1.20 * baseline["median_seconds"]:
+                      regression = f"Native R-MinHash exceeds 20% per-case slowdown: n={key[1]}, k={key[2]}"
+                      if r_migration:
+                          print(f"{regression}; v1->v2 family migration uses aggregate performance and accuracy gates")
+                      else:
+                          native_regressions.append(regression)
+          # Equal weight per size/width prevents long cases from dominating.
+          native_mean_log_ratio = sum(native_log_ratios) / len(native_log_ratios)
+          if native_mean_log_ratio > math.log(1.10):
+              native_regressions.append("Native R-MinHash geometric-mean slowdown exceeds 10%")
+          print(f"Native R-MinHash geometric-mean slowdown across {len(native_log_ratios)} cases: "
+                f"{math.expm1(native_mean_log_ratio):.2%}; maximum allowed: 10%")
+          if native_regressions:
+              raise SystemExit("\n".join(native_regressions))
           PY
 
       - name: Run full benchmark smoke
@@ -466,6 +578,13 @@ jobs:
             --seeds 8 --skip-retrieval \
             --output-json .bench/head_accuracy.json \
             | tee .bench/head_accuracy.txt
+
+          .venv/bin/python benchmarks/sketch_benchmark.py \
+            --engines rensa_classic fastsketch --rows 256 --repetitions 5 \
+            --min-sample-seconds 0.1 \
+            --sizes 1 8 32 128 1024 4096 --num-perm 128 512 \
+            --output-json .bench/head_sketches.json \
+            | tee .bench/head_sketches.txt
 
           .venv/bin/python benchmarks/simple_benchmark.py \
             --dataset "${BENCH_DATASET_KEY}" \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,13 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
       - name: Check formatting
         run: cargo fmt --all -- --check
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.9"
+      - name: Run Rust tests
+        run: cargo test --locked
       - name: Lint with clippy
-        run: cargo clippy --all --benches --tests --examples --all-features -- -D clippy::pedantic -D clippy::nursery
+        run: cargo clippy --locked --all --benches --tests --examples --all-features -- -D warnings -D clippy::pedantic -D clippy::nursery
 
   cargo-deny:
     name: Cargo Deny
@@ -224,7 +229,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: "3.9"
+          python-version: "3.13"
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
         with:
           enable-cache: true
@@ -251,7 +256,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          uv venv --python 3.9 "${GITHUB_WORKSPACE}/.venv"
+          uv venv --python 3.13 "${GITHUB_WORKSPACE}/.venv"
           uv sync --python "${GITHUB_WORKSPACE}/.venv/bin/python" --group dev --no-install-project
           uv pip install \
             --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
@@ -261,7 +266,7 @@ jobs:
           uv pip install \
             --no-cache \
             --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
-            "FastSketchLSH"
+            "FastSketchLSH==1.0.1"
           BENCH_VENV="${GITHUB_WORKSPACE}/.venv"
           BENCH_PY="${GITHUB_WORKSPACE}/.venv/bin/python"
           BENCH_MATURIN="${GITHUB_WORKSPACE}/.venv/bin/maturin"
@@ -286,6 +291,11 @@ jobs:
               --measured-runs "${BENCH_PR_MEASURED_RUNS}" \
               --output-json "${output_json}" \
               | tee "${output_log}"
+
+            RAYON_NUM_THREADS=1 "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/kernel_benchmark.py" \
+              --rows 256 --repetitions 5 --sizes 8 128 4096 --num-perm 128 512 \
+              --output-json "${output_json%.json}_kernels.json" \
+              | tee "${output_log%.txt}_kernels.txt"
 
             echo "Completed ${label} benchmark."
           }
@@ -322,22 +332,64 @@ jobs:
               if engine not in base["summary"]["engine_medians"]:
                   raise SystemExit(f"missing base engine metrics: {engine}")
 
-          head_total = float(head["summary"]["engine_medians"]["rensa_r"]["median_total"])
-          base_total = float(base["summary"]["engine_medians"]["rensa_r"]["median_total"])
-          if base_total <= 0:
-              raise SystemExit("invalid base rensa_r median_total")
-          slowdown_fraction = (head_total / base_total) - 1.0
-
-          if slowdown_fraction > 0.10:
-              raise SystemExit(
-                  f"rensa_r slowdown too high: head={head_total:.6f}s base={base_total:.6f}s "
-                  f"slowdown={slowdown_fraction:.2%}"
-              )
-
-          print(
-              f"PASS: rensa_r median_total head={head_total:.6f}s "
-              f"base={base_total:.6f}s slowdown={slowdown_fraction:.2%}"
+          config_keys = (
+              "dataset", "dataset_spec", "rows", "effective_max_rows", "num_perm",
+              "num_bands", "rows_per_band", "threshold", "seed", "ngram_size",
+              "warmup_runs", "measured_runs", "thread_env", "rensa_env", "token_cache_sha256",
           )
+          for key in config_keys:
+              if head["config"][key] != base["config"][key]:
+                  raise SystemExit(f"benchmark input/config mismatch: {key}")
+
+          for engine in required_engines:
+              flag_hashes = {
+                  run["duplicate_flags_sha256"][engine]
+                  for payload in (head, base)
+                  for run in payload["runs"]
+              }
+              if len(flag_hashes) != 1:
+                  raise SystemExit(f"duplicate decisions changed or are nondeterministic: {engine}")
+
+          for engine in ("rensa_r", "rensa_c"):
+              head_total = float(head["summary"]["engine_medians"][engine]["median_total"])
+              base_total = float(base["summary"]["engine_medians"][engine]["median_total"])
+              if not (0 < head_total < float("inf") and 0 < base_total < float("inf")):
+                  raise SystemExit(f"invalid {engine} median_total")
+              slowdown_fraction = (head_total / base_total) - 1.0
+              if slowdown_fraction > 0.10:
+                  raise SystemExit(
+                      f"{engine} slowdown too high: head={head_total:.6f}s base={base_total:.6f}s "
+                      f"slowdown={slowdown_fraction:.2%}"
+                  )
+              print(
+                  f"PASS: {engine} median_total head={head_total:.6f}s "
+                  f"base={base_total:.6f}s slowdown={slowdown_fraction:.2%}; duplicate decisions unchanged"
+              )
+          with open(".bench/head_kernels.json", "r", encoding="utf-8") as handle:
+              head_kernels = json.load(handle)
+          with open(".bench/base_kernels.json", "r", encoding="utf-8") as handle:
+              base_kernels = json.load(handle)
+          if head_kernels["config"] != base_kernels["config"]:
+              raise SystemExit("kernel benchmark config mismatch")
+          if head_kernels["environment"]["flags"] != base_kernels["environment"]["flags"]:
+              raise SystemExit("kernel benchmark environment flags mismatch")
+          def keyed_results(payload):
+              return {
+                  (result["case"], result["tokens_per_row"], result["num_perm"]): result
+                  for result in payload["results"]
+              }
+          head_cases = keyed_results(head_kernels)
+          base_cases = keyed_results(base_kernels)
+          if not head_cases or head_cases.keys() != base_cases.keys():
+              raise SystemExit("kernel benchmark cases mismatch or empty")
+          for key, result in head_cases.items():
+              baseline = base_cases[key]
+              if result["sha256"] != baseline["sha256"]:
+                  raise SystemExit(f"kernel output changed: {key}")
+              head_time, base_time = result["median_seconds"], baseline["median_seconds"]
+              if not (0 < head_time < float("inf") and 0 < base_time < float("inf")):
+                  raise SystemExit(f"invalid kernel timings: {key}")
+              print(f"Kernel {key}: {base_time / head_time:.3f}x speedup; output unchanged")
           PY
 
       - name: Run full benchmark smoke
@@ -345,6 +397,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" PATH="${GITHUB_WORKSPACE}/.venv/bin:${PATH}" .venv/bin/maturin develop --release
           "${GITHUB_WORKSPACE}/.venv/bin/python" benchmarks/full_benchmark.py \
             --datasets "${BENCH_DATASET_KEY}" \
             --threads "1,8" \
@@ -362,7 +415,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          uv venv --python 3.9 .venv
+          uv venv --python 3.13 .venv
           uv sync --python .venv/bin/python --group dev --no-install-project
           uv pip install \
             --python .venv/bin/python \
@@ -372,7 +425,7 @@ jobs:
           uv pip install \
             --no-cache \
             --python .venv/bin/python \
-            "FastSketchLSH"
+            "FastSketchLSH==1.0.1"
 
           VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" PATH="${GITHUB_WORKSPACE}/.venv/bin:${PATH}" .venv/bin/maturin develop --release
 
@@ -448,21 +501,24 @@ jobs:
           fi
 
   test:
-    name: Run Tests
+    name: Run Tests (Python ${{ matrix.python }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        python: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python }}
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
         with:
           enable-cache: true
       
       - name: Install dependencies
         run: |
-          uv venv --python 3.9 .venv
+          uv venv --python "${{ matrix.python }}" .venv
           uv sync --python .venv/bin/python --group dev --no-install-project
           
       - name: Build & Install Rensa

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -366,6 +366,16 @@ jobs:
               --output-json "${output_json%.json}_prehashed.json" \
               | tee "${output_log%.txt}_prehashed.txt"
 
+            if [ "${label}" = "head" ] && [ "${RENSA_REQUIRE_AVX512:-}" = "1" ]; then
+              # Compare both backends on the same CPU and installed head binary.
+              RENSA_FORCE_KERNEL=avx2 "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/sketch_benchmark.py" \
+                --prehashed --engines rensa_classic --rows 256 --repetitions 5 \
+                --min-sample-seconds 0.05 --max-input-tokens 8388608 \
+                --sizes 0 1 8 128 4096 65536 1048576 --num-perm 128 512 \
+                --output-json "${output_json%.json}_prehashed_avx2.json" \
+                | tee "${output_json%.json}_prehashed_avx2.txt"
+            fi
+
             echo "Completed ${label} benchmark."
           }
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -232,6 +232,7 @@ jobs:
     timeout-minutes: 30
     env:
       HF_HOME: ${{ github.workspace }}/.hf-cache
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
       BENCH_COMPARE: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.performance_only) }}
       BENCH_DATASET_KEY: ag_news
       BENCH_MAX_ROWS: "10000"
@@ -374,6 +375,20 @@ jobs:
                 --sizes 0 1 8 128 4096 65536 1048576 --num-perm 128 512 \
                 --output-json "${output_json%.json}_prehashed_avx2.json" \
                 | tee "${output_json%.json}_prehashed_avx2.txt"
+
+              "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/sketch_benchmark.py" \
+                --prehashed --engines rensa_classic --repeat-cardinality 4 --rows 8 \
+                --repetitions 5 --min-sample-seconds 0.05 --max-input-tokens 8388608 \
+                --sizes 65536 1048576 --num-perm 128 512 \
+                --output-json "${output_json%.json}_prehashed_repeated.json" \
+                | tee "${output_json%.json}_prehashed_repeated.txt"
+
+              RENSA_FORCE_KERNEL=avx2 "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/sketch_benchmark.py" \
+                --prehashed --engines rensa_classic --repeat-cardinality 4 --rows 8 \
+                --repetitions 5 --min-sample-seconds 0.05 --max-input-tokens 8388608 \
+                --sizes 65536 1048576 --num-perm 128 512 \
+                --output-json "${output_json%.json}_prehashed_repeated_avx2.json" \
+                | tee "${output_json%.json}_prehashed_repeated_avx2.txt"
             fi
 
             echo "Completed ${label} benchmark."
@@ -390,6 +405,52 @@ jobs:
             "${GITHUB_WORKSPACE}/.bench/base.json" \
             "${GITHUB_WORKSPACE}/.bench/base_summary.txt" \
             "base"
+
+      - name: Validate repeated-token backend diagnostics
+        if: env.BENCH_COMPARE == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! grep -qw avx512f /proc/cpuinfo || ! grep -qw avx512dq /proc/cpuinfo; then
+            exit 0
+          fi
+          "${GITHUB_WORKSPACE}/.venv/bin/python" - <<'PY' | tee .bench/validation_repeated.txt
+          import json
+
+          reports = []
+          for suffix, backend in (("", None), ("_avx2", "avx2")):
+              with open(f".bench/head_prehashed_repeated{suffix}.json", encoding="utf-8") as handle:
+                  report = json.load(handle)
+              if report["environment"]["flags"].pop("RENSA_FORCE_KERNEL", None) != backend:
+                  raise SystemExit("repeated-token diagnostic backend mismatch")
+              reports.append(report)
+          default, avx2 = reports
+          if default["config"] != avx2["config"] or default["environment"] != avx2["environment"]:
+              raise SystemExit("repeated-token diagnostic config/environment mismatch")
+          expected_config = {"prehashed": True, "engines": ["rensa_classic"],
+                             "repeat_cardinality": 4, "rows": 8, "repetitions": 5,
+                             "min_sample_seconds": 0.05, "max_input_tokens": 8388608,
+                             "sizes": [65536, 1048576], "num_perm": [128, 512], "in_process": False}
+          if any(default["config"][key] != value for key, value in expected_config.items()):
+              raise SystemExit("repeated-token diagnostic matrix mismatch")
+          expected_cases = {(size, k) for size in (65536, 1048576) for k in (128, 512)}
+          rows = []
+          for report in reports:
+              cases = {(row["tokens_per_row"], row["num_perm"]): row for row in report["results"]}
+              if cases.keys() != expected_cases or len(report["results"]) != len(expected_cases):
+                  raise SystemExit("repeated-token diagnostic cases missing or duplicated")
+              if any(row["engine"] != "rensa_classic" or row["rows"] != 8
+                     or row["distinct_tokens_per_row"] != 4 for row in cases.values()):
+                  raise SystemExit("repeated-token diagnostic inputs mismatch")
+              rows.append(cases)
+          for case, result in rows[0].items():
+              forced = rows[1][case]
+              if any(result[key] != forced[key] for key in ("input_sha256", "sha256")):
+                  raise SystemExit(f"repeated-token diagnostic hash mismatch: {case}")
+              print(f"PASS: repeated tokens n={case[0]}, k={case[1]}: "
+                    f"default={result['median_seconds']:.6f}s, avx2={forced['median_seconds']:.6f}s; "
+                    f"avx2/default={forced['median_seconds'] / result['median_seconds']:.3f}x")
+          PY
 
       - name: Validate benchmark outputs
         if: env.BENCH_COMPARE == 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -283,6 +283,10 @@ jobs:
             VIRTUAL_ENV="${BENCH_VENV}" PATH="${BENCH_VENV}/bin:${PATH}" "${BENCH_MATURIN}" develop --release
             popd >/dev/null
 
+            if [ "${label}" = "head" ]; then
+              "${BENCH_PY}" -m pytest -q "${GITHUB_WORKSPACE}/tests/test_accuracy.py"
+            fi
+
             "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/simple_benchmark.py" \
               --dataset "${BENCH_DATASET_KEY}" \
               --max-rows "${BENCH_MAX_ROWS}" \
@@ -298,6 +302,11 @@ jobs:
               --rows 256 --repetitions 5 --sizes 1 8 32 128 4096 --num-perm 128 512 \
               --output-json "${output_json%.json}_kernels.json" \
               | tee "${output_log%.txt}_kernels.txt"
+
+            "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/accuracy_benchmark.py" \
+              --seeds 8 --skip-retrieval \
+              --output-json "${output_json%.json}_accuracy.json" \
+              | tee "${output_log%.txt}_accuracy.txt"
 
             echo "Completed ${label} benchmark."
           }
@@ -343,14 +352,25 @@ jobs:
               if head["config"][key] != base["config"][key]:
                   raise SystemExit(f"benchmark input/config mismatch: {key}")
 
+          c_versions = (base["metadata"]["cminhash_algorithm_version"],
+                        head["metadata"]["cminhash_algorithm_version"])
+          # The bias correction changes C signatures once, from version 1 to 2.
+          # Same-version comparisons retain every output check.
+          c_migration = c_versions == (1, 2)
+          if c_versions[0] != c_versions[1] and not c_migration:
+              raise SystemExit(f"unsupported C-MinHash algorithm transition: {c_versions}")
+          if c_migration:
+              print("C-MinHash 1->2 correction: compare accuracy artifacts; require per-build determinism")
+
           for engine in required_engines:
-              flag_hashes = {
-                  run["duplicate_flags_sha256"][engine]
-                  for payload in (head, base)
-                  for run in payload["runs"]
-              }
-              if len(flag_hashes) != 1:
-                  raise SystemExit(f"duplicate decisions changed or are nondeterministic: {engine}")
+              flag_hashes = []
+              for payload in (head, base):
+                  hashes = {run["duplicate_flags_sha256"][engine] for run in payload["runs"]}
+                  if len(hashes) != 1:
+                      raise SystemExit(f"duplicate decisions are nondeterministic or missing: {engine}")
+                  flag_hashes.append(hashes.pop())
+              if flag_hashes[0] != flag_hashes[1] and not (c_migration and engine == "rensa_c"):
+                  raise SystemExit(f"duplicate decisions changed: {engine}")
 
           for engine in ("rensa_r", "rensa_c"):
               head_total = float(head["summary"]["engine_medians"][engine]["median_total"])
@@ -363,9 +383,13 @@ jobs:
                       f"{engine} slowdown too high: head={head_total:.6f}s base={base_total:.6f}s "
                       f"slowdown={slowdown_fraction:.2%}"
                   )
+              decision_check = (
+                  "C-MinHash 1->2 correction; per-build decisions deterministic"
+                  if c_migration and engine == "rensa_c" else "duplicate decisions unchanged"
+              )
               print(
                   f"PASS: {engine} median_total head={head_total:.6f}s "
-                  f"base={base_total:.6f}s slowdown={slowdown_fraction:.2%}; duplicate decisions unchanged"
+                  f"base={base_total:.6f}s slowdown={slowdown_fraction:.2%}; {decision_check}"
               )
           with open(".bench/head_kernels.json", "r", encoding="utf-8") as handle:
               head_kernels = json.load(handle)
@@ -375,6 +399,10 @@ jobs:
               raise SystemExit("kernel benchmark config mismatch")
           if head_kernels["environment"]["flags"] != base_kernels["environment"]["flags"]:
               raise SystemExit("kernel benchmark environment flags mismatch")
+          kernel_c_versions = (base_kernels["environment"]["cminhash_algorithm_version"],
+                               head_kernels["environment"]["cminhash_algorithm_version"])
+          if kernel_c_versions != c_versions:
+              raise SystemExit("C-MinHash algorithm versions differ between benchmark suites")
           def keyed_results(payload):
               return {
                   (result["case"], result["tokens_per_row"], result["num_perm"]): result
@@ -386,12 +414,14 @@ jobs:
               raise SystemExit("kernel benchmark cases mismatch or empty")
           for key, result in head_cases.items():
               baseline = base_cases[key]
-              if result["sha256"] != baseline["sha256"]:
+              c_signature_migration = c_migration and key[0] in ("c_update", "c_prehashed")
+              if result["sha256"] != baseline["sha256"] and not c_signature_migration:
                   raise SystemExit(f"kernel output changed: {key}")
               head_time, base_time = result["median_seconds"], baseline["median_seconds"]
               if not (0 < head_time < float("inf") and 0 < base_time < float("inf")):
                   raise SystemExit(f"invalid kernel timings: {key}")
-              print(f"Kernel {key}: {base_time / head_time:.3f}x speedup; output unchanged")
+              output_check = "C-MinHash 1->2 signature correction" if c_signature_migration else "output unchanged"
+              print(f"Kernel {key}: {base_time / head_time:.3f}x speedup; {output_check}")
           PY
 
       - name: Run full benchmark smoke
@@ -430,6 +460,12 @@ jobs:
             "FastSketchLSH==1.0.1"
 
           VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" PATH="${GITHUB_WORKSPACE}/.venv/bin:${PATH}" .venv/bin/maturin develop --release
+
+          .venv/bin/python -m pytest -q tests/test_accuracy.py
+          .venv/bin/python benchmarks/accuracy_benchmark.py \
+            --seeds 8 --skip-retrieval \
+            --output-json .bench/head_accuracy.json \
+            | tee .bench/head_accuracy.txt
 
           .venv/bin/python benchmarks/simple_benchmark.py \
             --dataset "${BENCH_DATASET_KEY}" \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,10 @@ on:
         description: Run only strict performance comparisons against origin/main
         type: boolean
         default: false
+      require_avx512:
+        description: Fail before benchmarking if the runner lacks AVX-512F/DQ
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -256,12 +260,19 @@ jobs:
 
       - name: Record benchmark hardware and compilers
         shell: bash
+        env:
+          REQUIRE_AVX512: ${{ inputs.require_avx512 || false }}
         run: |
           set -euo pipefail
           mkdir -p .bench
           git rev-parse HEAD | tee .bench/head_commit.txt
           lscpu --json > .bench/cpu.json
           lscpu | tee .bench/cpu.txt
+          if [ "${REQUIRE_AVX512}" = "true" ] && \
+             { ! grep -qw avx512f /proc/cpuinfo || ! grep -qw avx512dq /proc/cpuinfo; }; then
+            echo "Requested AVX-512F/DQ is unavailable on this runner." >&2
+            exit 1
+          fi
           {
             c++ --version
             rustc -vV

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -295,7 +295,7 @@ jobs:
               | tee "${output_log}"
 
             RAYON_NUM_THREADS=1 "${BENCH_PY}" "${GITHUB_WORKSPACE}/benchmarks/kernel_benchmark.py" \
-              --rows 256 --repetitions 5 --sizes 8 128 4096 --num-perm 128 512 \
+              --rows 256 --repetitions 5 --sizes 1 8 32 128 4096 --num-perm 128 512 \
               --output-json "${output_json%.json}_kernels.json" \
               | tee "${output_log%.txt}_kernels.txt"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,11 @@ on:
       - "*"
   pull_request:
   workflow_dispatch:
+    inputs:
+      performance_only:
+        description: Run only strict performance comparisons against origin/main
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,6 +24,7 @@ permissions:
 
 jobs:
   rust-quality:
+    if: github.event_name != 'workflow_dispatch' || !inputs.performance_only
     name: Rust Quality
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -37,10 +43,15 @@ jobs:
         run: |
           lscpu
           cargo test --locked
+      - name: Check minimum supported Rust version
+        run: |
+          rustup toolchain install 1.83.0 --profile minimal
+          cargo +1.83.0 test --locked --lib simd::
       - name: Lint with clippy
         run: cargo clippy --locked --all --benches --tests --examples --all-features -- -D warnings -D clippy::pedantic -D clippy::nursery
 
   cargo-deny:
+    if: github.event_name != 'workflow_dispatch' || !inputs.performance_only
     name: Cargo Deny
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -71,6 +82,7 @@ jobs:
           fail-on-severity: moderate
 
   linux:
+    if: github.event_name != 'workflow_dispatch' || !inputs.performance_only
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -108,6 +120,7 @@ jobs:
 
 
   musllinux:
+    if: github.event_name != 'workflow_dispatch' || !inputs.performance_only
     runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
@@ -140,6 +153,7 @@ jobs:
           path: dist
 
   windows:
+    if: github.event_name != 'workflow_dispatch' || !inputs.performance_only
     runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
@@ -168,6 +182,7 @@ jobs:
           path: dist
 
   macos:
+    if: github.event_name != 'workflow_dispatch' || !inputs.performance_only
     runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
@@ -195,6 +210,7 @@ jobs:
           path: dist
 
   sdist:
+    if: github.event_name != 'workflow_dispatch' || !inputs.performance_only
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -216,6 +232,7 @@ jobs:
     timeout-minutes: 30
     env:
       HF_HOME: ${{ github.workspace }}/.hf-cache
+      BENCH_COMPARE: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.performance_only) }}
       BENCH_DATASET_KEY: ag_news
       BENCH_MAX_ROWS: "10000"
       BENCH_FULL_SMOKE_MAX_ROWS: "2000"
@@ -236,24 +253,42 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Create benchmark directories
-        shell: bash
-        run: |
-          mkdir -p .bench
-
-      - name: Prepare PR base checkout
-        if: github.event_name == 'pull_request'
+      - name: Record benchmark hardware and compilers
         shell: bash
         run: |
           set -euo pipefail
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          echo "Base SHA: ${BASE_SHA}"
-          git fetch --no-tags origin "${BASE_SHA}"
+          mkdir -p .bench
+          git rev-parse HEAD | tee .bench/head_commit.txt
+          lscpu --json > .bench/cpu.json
+          lscpu | tee .bench/cpu.txt
+          {
+            c++ --version
+            rustc -vV
+            cargo --version
+            uv --version
+          } | tee .bench/compilers.txt
+
+      - name: Prepare benchmark base checkout
+        if: env.BENCH_COMPARE == 'true'
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PR_BASE_SHA}" ]; then
+            BASE_SHA="${PR_BASE_SHA}"
+            git fetch --no-tags origin "${BASE_SHA}"
+          else
+            # Resolve main once, so a manual run compares both builds to one commit.
+            git fetch --no-tags origin main
+            BASE_SHA="$(git rev-parse FETCH_HEAD)"
+          fi
+          printf '%s\n' "${BASE_SHA}" | tee .bench/base_commit.txt
           git worktree add ../rensa-base "${BASE_SHA}"
           echo "BASE_DIR=$(cd ../rensa-base && pwd)" >> "$GITHUB_ENV"
 
-      - name: Run PR base and head benchmarks
-        if: github.event_name == 'pull_request'
+      - name: Run base and head benchmarks
+        if: env.BENCH_COMPARE == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -266,9 +301,11 @@ jobs:
             "datasketch>=1.9" \
             "tqdm>=4.66"
           uv pip install \
-            --no-cache \
+            --no-cache --no-binary FastSketchLSH --verbose \
             --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
-            "FastSketchLSH==1.0.1"
+            "FastSketchLSH==1.0.1" 2>&1 | tee .bench/fastsketch_build.txt
+          # Upstream chooses AVX-512 at build time; retain its actual selection.
+          grep -F 'Selected SIMD:' .bench/fastsketch_build.txt | tee .bench/fastsketch_simd.txt
           BENCH_VENV="${GITHUB_WORKSPACE}/.venv"
           BENCH_PY="${GITHUB_WORKSPACE}/.venv/bin/python"
           BENCH_MATURIN="${GITHUB_WORKSPACE}/.venv/bin/maturin"
@@ -284,6 +321,11 @@ jobs:
             popd >/dev/null
 
             if [ "${label}" = "head" ]; then
+              if grep -qw avx512f /proc/cpuinfo && grep -qw avx512dq /proc/cpuinfo; then
+                export RENSA_REQUIRE_AVX512=1
+              fi
+              PYO3_PYTHON="${BENCH_PY}" cargo test --locked --lib simd:: -- --nocapture \
+                2>&1 | tee .bench/simd_tests.txt
               "${BENCH_PY}" -m pytest -q \
                 "${GITHUB_WORKSPACE}/tests/test_accuracy.py" \
                 "${GITHUB_WORKSPACE}/tests/test_rensa.py"
@@ -339,8 +381,8 @@ jobs:
             "${GITHUB_WORKSPACE}/.bench/base_summary.txt" \
             "base"
 
-      - name: Validate PR benchmark outputs
-        if: github.event_name == 'pull_request'
+      - name: Validate benchmark outputs
+        if: env.BENCH_COMPARE == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -561,7 +603,7 @@ jobs:
           PY
 
       - name: Run full benchmark smoke
-        if: github.event_name == 'pull_request'
+        if: env.BENCH_COMPARE == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -579,7 +621,7 @@ jobs:
             | tee .bench/full_head_smoke_summary.txt
 
       - name: Run push smoke benchmark
-        if: github.event_name != 'pull_request'
+        if: env.BENCH_COMPARE != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -591,12 +633,18 @@ jobs:
             "datasketch>=1.9" \
             "tqdm>=4.66"
           uv pip install \
-            --no-cache \
+            --no-cache --no-binary FastSketchLSH --verbose \
             --python .venv/bin/python \
-            "FastSketchLSH==1.0.1"
+            "FastSketchLSH==1.0.1" 2>&1 | tee .bench/fastsketch_build.txt
+          grep -F 'Selected SIMD:' .bench/fastsketch_build.txt | tee .bench/fastsketch_simd.txt
 
           VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" PATH="${GITHUB_WORKSPACE}/.venv/bin:${PATH}" .venv/bin/maturin develop --release
 
+          if grep -qw avx512f /proc/cpuinfo && grep -qw avx512dq /proc/cpuinfo; then
+            export RENSA_REQUIRE_AVX512=1
+          fi
+          PYO3_PYTHON="${GITHUB_WORKSPACE}/.venv/bin/python" cargo test --locked --lib simd:: -- --nocapture \
+            2>&1 | tee .bench/simd_tests.txt
           .venv/bin/python -m pytest -q tests/test_accuracy.py tests/test_rensa.py
           .venv/bin/python benchmarks/accuracy_benchmark.py \
             --seeds 8 --skip-retrieval \
@@ -641,7 +689,7 @@ jobs:
             | tee .bench/full_head_smoke_summary.txt
 
       - name: Validate push smoke benchmark outputs
-        if: github.event_name != 'pull_request'
+        if: env.BENCH_COMPARE != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -680,8 +728,8 @@ jobs:
             .bench/*.json
             .bench/*.txt
 
-      - name: Cleanup PR base checkout
-        if: always() && github.event_name == 'pull_request'
+      - name: Cleanup benchmark base checkout
+        if: always() && env.BENCH_COMPARE == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -690,6 +738,7 @@ jobs:
           fi
 
   test:
+    if: github.event_name != 'workflow_dispatch' || !inputs.performance_only
     name: Run Tests (Python ${{ matrix.python }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -722,7 +771,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: startsWith(github.ref, 'refs/tags/') && (github.event_name != 'workflow_dispatch' || !inputs.performance_only)
     needs: [rust-quality, cargo-deny, linux, musllinux, windows, macos, sdist, performance-check, test]
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/.bench
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Rensa also includes C-MinHash, based on the [C-MinHash paper](https://arxiv.org/
 
 For batches with at least 128 tokens and 128 permutations, C-MinHash sorts the transformed token values and finds the minimum for each wrapping offset by binary search. This produces the same signature with O(n log n + k log n) work instead of O(nk), using an additional 8-byte temporary value per token. Streaming duplicate checks stop comparing a pair once its remaining signature slots cannot meet the threshold.
 
+`CMinHashDeduplicator` builds an exact candidate index after 128 stored entries. If the threshold permits `d` mismatching signature slots, it partitions the signature into `d + 1` disjoint bands: every accepted duplicate must match at least one complete band. Candidates still pass the same signature comparison, so hash collisions only cause extra checks. This accelerates insertion and boolean duplicate checks at the cost of additional memory proportional to stored entries times band count. Singleton buckets stay inline. Collections initially use a scan, and thresholds requiring at most one matching slot always use a scan. `get_duplicates()` retains its full scan.
+
 ## Installation
 
 ```bash
@@ -262,7 +264,9 @@ uv run python benchmarks/full_benchmark.py
 
 - `benchmarks/simple_benchmark.py`: single-thread quick comparison across Datasketch, FastSketch, R-MinHash, and C-MinHash.
 - `benchmarks/full_benchmark.py`: fair per-run process-isolated benchmark (all engines per subprocess, randomized order) across Datasketch, FastSketch, and Rensa on the full dataset preset suite.
-- `benchmarks/kernel_benchmark.py`: deterministic Rensa-only timings for classic sketching, rho sketching, and duplicate queries, with exact output hashes for comparing builds. For example: `RAYON_NUM_THREADS=1 uv run python benchmarks/kernel_benchmark.py --output-json .bench/kernels.json`.
+- `benchmarks/kernel_benchmark.py`: deterministic Rensa-only timings for token hashing, classic and rho sketching, streaming C-MinHash insertion, and duplicate queries, with exact output hashes for comparing builds. For example: `RAYON_NUM_THREADS=1 uv run python benchmarks/kernel_benchmark.py --output-json .bench/kernels.json`.
+
+Kernel measurements default to 200 ms of untimed warmup and at least 100 ms per sample. For noisy multi-thread measurements, run individual cases in fresh processes using `--cases`, `--sizes`, and `--num-perm`, increase `--min-sample-seconds`, and alternate the order of the builds. Keep all samples; large timing dispersion makes a comparison inconclusive.
 
 `simple_benchmark.py` times `rensa_c`, but excludes it from accuracy comparisons because `CMinHashDeduplicator.add_pairs` uses streaming add-if-unique semantics rather than batch query-all semantics.
 

--- a/README.md
+++ b/README.md
@@ -1,75 +1,142 @@
 # Rensa
 
-High-performance MinHash in Rust with Python bindings, with SIMD sketching and batch deduplication APIs.
+[![CI](https://github.com/beowolx/rensa/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/beowolx/rensa/actions/workflows/CI.yml)
+[![PyPI](https://img.shields.io/pypi/v/rensa.svg)](https://pypi.org/project/rensa/)
+[![Python](https://img.shields.io/badge/python-%3E%3D3.8-blue.svg)](https://pypi.org/project/rensa/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## What is Rensa?
+Rensa is a MinHash library written in Rust with Python bindings. It estimates
+Jaccard similarity from compact signatures and finds near-duplicate documents
+using locality-sensitive hashing (LSH). Rensa supports batch and streaming
+deduplication on Linux, macOS and Windows.
 
-Rensa (Swedish for "clean") computes MinHash signatures for similarity estimation and deduplication, including approximate batch processing for finding near-duplicates in large datasets.
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1o1nzwXWAa8kdkEJljbJFW1VuI-3VZLUn?usp=sharing)
+Try it in [Maxime Labonne's AutoDedup notebook](#playground).
 
-It ships two MinHash variants:
+## Contents
 
-- **R-MinHash**: Full-set similarity sketching with seeded bucket rounds, a SIMD fallback, and 32-bit signature slots.
-- **C-MinHash**: A practical approximation of [circulant MinHash](https://proceedings.mlr.press/v162/li22m.html), with 64-bit signature slots and nonlinear permutations.
+- [Quick comparison with other tools](#quick-comparison-with-other-tools)
+- [Why should I use Rensa?](#why-should-i-use-rensa)
+- [Why shouldn't I use Rensa?](#why-shouldnt-i-use-rensa)
+- [Is it really faster than everything else?](#is-it-really-faster-than-everything-else)
+- [Playground](#playground)
+- [Installation](#installation)
+- [Usage](#usage)
 
-The separate **rho batch path** samples token positions to accelerate duplicate detection. Its recall depends on document length and token order, so its speed should be evaluated together with retrieval accuracy. Use the classic full-set APIs when you need order-invariant Jaccard estimates.
+## Quick comparison with other tools
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1o1nzwXWAa8kdkEJljbJFW1VuI-3VZLUn?usp=sharing) &nbsp; Thanks [mlabonne](https://github.com/mlabonne) for the Colab notebook!
+Rensa's rho batch pipeline averaged **600× faster than Datasketch** and
+**12× faster than FastSketch**.
 
-## Performance
-
-The historical reference run below used `benchmarks/full_benchmark.py` over 7 datasets and 2 thread lanes (`threads=1,8`), 128 permutations, threshold 0.8, and 8 bands. Its raw results, hardware details, and dependency versions are not checked in, so these figures should not be treated as a verified comparison of current releases.
-
-![Deduplication speed: full benchmark suite](./assets/bench_time_full_suite.png)
+![Deduplication time for Rensa compared with Datasketch and FastSketch across seven datasets](assets/bench_time_full_suite.png)
 
 | Comparison | Average speedup |
-| ---------- | --------------- |
-| **Rensa vs Datasketch** | **608.52x faster** |
-| **Rensa vs FastSketch** | **11.92x faster** |
+| --- | ---: |
+| Rensa vs. [Datasketch](https://ekzhu.com/datasketch/) | **608.52× faster** |
+| Rensa vs. [FastSketch](https://github.com/pzcddm/FastSketchLSH) | **11.92× faster** |
 
-| Agreement vs Datasketch | Value |
-| ---------------------- | ----- |
-| Mean Jaccard of kept sets | 0.987219 |
-| Mean duplicate-flag mismatch rate | 0.010717 |
+The [benchmark](benchmarks/full_benchmark.py) measures sketch construction and
+duplicate detection together across seven datasets, using 128 signature slots,
+eight LSH bands, a 0.8 threshold, and both one-thread and eight-thread runs. It
+uses Rensa's rho pipeline, which samples token positions to increase throughput.
+The [performance section](#is-it-really-faster-than-everything-else) explains how
+that differs from full-set MinHash.
 
-These agreement metrics are from the same full benchmark run as the speed numbers above. They compare duplicate decisions with Datasketch, not with exact Jaccard ground truth. The benchmark uses Rensa’s approximate rho matrix and one-shot duplicate flags. Current FastSketchLSH also uses its fused duplicate-flag API; older versions fall back to candidate lists, as does Datasketch. The speedups describe these deduplication pipelines, not every MinHash API or workload.
+## Why should I use Rensa?
 
-## How R-MinHash works
+- You want to find near-duplicates in a dataset without comparing every pair of
+  documents. With LSH enabled, `RMinHashDeduplicator` finds candidate matches and
+  checks their estimated similarity against your threshold.
+- You want to process a batch or keep filtering documents as they arrive. The
+  batch APIs build sketches from token lists in one call; streaming
+  deduplicators retain their indexes between calls.
+- You need compact signatures. R-MinHash uses 32 bits per slot, so a 128-slot
+  signature occupies **512 bytes**, excluding object overhead. The signature
+  stays the same size as the document grows.
+- You need to update a sketch incrementally. Full-set R-MinHash gives the same
+  signature when tokens are reordered, repeated or split across updates.
+- You already tokenize your data in Python. Rensa accepts token iterables,
+  including strings and bytes, and provides prehashed input APIs when you want
+  to reuse token hashes.
 
-MinHash estimates Jaccard similarity from the fraction of matching signature slots. R-MinHash version 2 uses every input token and a fixed family of hash functions for each `(num_perm, seed)`. Reordering tokens, repeating tokens, or dividing them across incremental updates produces the same signature.
+Rensa provides full-set **R-MinHash** and **C-MinHash** for similarity estimation,
+along with a separate **rho pipeline** for faster bulk filtering. Choose full-set
+R-MinHash when token order should have no effect on the result. Rho samples token
+positions, so document length and token order affect which duplicates it finds.
 
-The sketch uses three seeded bucket rounds. In each round, a token's hash chooses one of the `num_perm` slots and a rank within that round. Each slot keeps its smallest rank, with earlier rounds taking priority. For a nonempty set, any slot left empty after these rounds receives the actual minimum of its own separately seeded fallback hash over all tokens in the set. Fallback values are computed from tokens, not copied from another bucket. Taking the minimum across updates preserves the same result as processing their union at once.
+## Why shouldn't I use Rensa?
 
-This is a practical variant of [Fast Similarity Sketching](https://arxiv.org/abs/1704.04370), truncated to a fixed number of bucket rounds before fallback. It uses SplitMix64 mixing for bucket selection and nonlinear mixing followed by seeded affine multiply-shift hashes for fallback. These are approximations to fully random hash functions; the published algorithm's concentration and expected-time guarantees are not established for this variant. Rensa checks its bias, estimation error, and retrieval accuracy against exact Jaccard in `benchmarks/accuracy_benchmark.py`.
+- You need exact similarity or guaranteed duplicate detection. MinHash estimates
+  similarity, and LSH can miss matching pairs. Use exact set comparisons if
+  those errors are unacceptable.
+- You need semantic similarity. Rensa compares token overlap. Two paraphrases
+  can mean the same thing and share very few tokens.
+- You need other sketches, such as Weighted MinHash or HyperLogLog.
+  [Datasketch](https://ekzhu.com/datasketch/) supports both.
+- You have a workload where another implementation is faster. Document size,
+  signature size and how much work you send through each Python call all matter.
+  If Rensa is unexpectedly slow, please [open an issue](https://github.com/beowolx/rensa/issues)
+  with a small reproducer.
 
-Each `u32` slot stores a 2-bit round tag and a 30-bit rank. At 128 slots, the signature values occupy 512 bytes, excluding object and allocation overhead.
+## Is it really faster than everything else?
 
-`RMinHash.ALGORITHM_VERSION` is **2**. **Rebuild existing R-MinHash signatures and LSH indexes from their original tokens:** legacy serialized sketches and indexes are rejected, and raw digest arrays from different algorithm versions must not be mixed. The separate rho representation is not interchangeable with an R-MinHash signature.
+Yes, by a wide margin in the batch benchmarks: about **600× faster than
+Datasketch** and **12× faster than FastSketch** on average. These results measure
+the complete rho batch pipeline, from sketch construction to duplicate detection.
 
-### Performance engineering
+Rensa is fast because:
 
-On top of the algorithm, Rensa applies several low-level optimizations.
+- **Fewer hash evaluations.** Classical MinHash evaluates a hash function for
+  every signature slot for each token. R-MinHash adapts
+  [Fast Similarity Sketching](https://arxiv.org/abs/1704.04370): each token chooses
+  a slot and rank in up to three seeded bucket rounds. Only slots still empty
+  after those rounds need their own fallback hash over all tokens. Dense inputs
+  can fill every slot during the bucket rounds and skip fallback entirely.
+- **Skipping updates that cannot change the result.** For sufficiently long,
+  dense inputs with power-of-two signature sizes, small signature values
+  establish an upper bound. R-MinHash can then discard updates that cannot
+  improve any slot and skip later rounds.
+  It produces the same signature as processing the full token set.
+- **SIMD where it pays off.** Runtime dispatch selects NEON, AVX2 or AVX-512
+  kernels when available. A few empty slots are handled directly; larger
+  fallback sets use SIMD batches. Some conditional bucket loops remain scalar
+  because scattering vector results would cost more than it saves.
+- **Less work at the Python boundary.** A CPython fast path reads compact ASCII
+  strings directly. Specialized list and tuple paths avoid temporary Rust
+  strings and a Python call for every token. Token hashing matches
+  `rustc_hash::FxHasher` without trait dispatch in the hot path, and prehashed
+  input skips token hashing altogether.
+- **Less repeated setup.** Sketches with the same `(num_perm, seed)` share
+  fallback parameters and their SIMD layouts. Short-input paths keep scratch
+  space on the stack, and standard builds use mimalloc for heap allocation.
+- **Batch processing in Rust.** Batch APIs write contiguous signature matrices
+  and can distribute large batches across Rayon workers. Native LSH processes a
+  whole matrix in one call, avoiding a Python sketch object and query call for
+  each document.
 
-Input elements are hashed with a fast non-cryptographic hash that mirrors `rustc_hash::FxHasher` semantics while avoiding trait dispatch in the hot path. The sketch then applies its seeded mixing stages to these token hashes.
+The rho pipeline samples token positions for bulk filtering. Full-set R-MinHash
+uses every token and gives the same signature when tokens are reordered or
+repeated. The [accuracy benchmark](benchmarks/accuracy_benchmark.py) checks
+estimation error and retrieval against exact Jaccard, including pairs whose
+tokens have been reordered.
 
-Dense inputs often fill every slot during the bucket rounds, allowing the kernel to skip fallback work. When many slots need fallback, a SIMD kernel evaluates the same fallback hashes together; when few remain, only those slots are evaluated. These paths change how the fixed hash family is evaluated, so short and long documents remain comparable and incremental updates preserve their meaning.
+Rensa also implements a practical variant of
+[C-MinHash](https://proceedings.mlr.press/v162/li22m.html), using two seeded
+nonlinear permutations and 64-bit signature slots. Its streaming deduplicator
+indexes candidate signatures and stops comparing a pair as soon as it cannot
+meet the threshold.
 
-Fallback coefficients are deterministic, derived from a seed via Xoshiro256++, and reused across updates. Their tables and SIMD layouts are shared process-wide per `(num_perm, seed)` to avoid repeated parameter setup. Constructing or cloning a sketch still requires O(`num_perm`) work to allocate or copy its signature values.
+## Playground
 
-Token extraction reads compact ASCII `str` data inline (the common case for tokenized text) instead of round-tripping through `PyUnicode_AsUTF8AndSize`.
+If you'd like to try Rensa before installing it,
+[Maxime Labonne](https://github.com/mlabonne) created an
+[AutoDedup notebook](https://colab.research.google.com/drive/1o1nzwXWAa8kdkEJljbJFW1VuI-3VZLUn?usp=sharing)
+that runs in Google Colab.
 
-The separate rho batch path can parallelize extraction for lists of ASCII/bytes tokens: worker threads read list items and string payloads directly from CPython object memory while the calling thread holds the GIL and runs no Python callbacks. Rows containing other token types fall back to the GIL thread. Rho's one-shot LSH deduplication groups rows by raw band hashes with intrusive chains, refines fold windows by exact hash-pair equality, and reuses collision counts for its recall-rescue pass. Band scans run in parallel when a Rayon pool is available.
-
-The global allocator is MiMalloc, which handles the batch-allocate-then-free pattern better than the system default. Rensa disables MiMalloc's eager arena commit at module load (unless overridden via `MIMALLOC_ARENA_EAGER_COMMIT`), which keeps peak RSS flat when many threads allocate short-lived sketch buffers.
-
-### C-MinHash
-
-Rensa follows the input rotation in Algorithm 3 of Xiaoyun Li and Ping Li's [C-MinHash paper](https://proceedings.mlr.press/v162/li22m/li22m.pdf): `h[k] = min(pi(sigma(x) - (k + 1)))`, with subtraction modulo 2^64. Two separately seeded [SplitMix64 finalizers](https://prng.di.unimi.it/splitmix64.c) provide nonlinear bijections over token hashes. These are compact pseudorandom approximations; the paper's unbiasedness and lower-variance proofs assume uniformly random permutation vectors and do not establish those guarantees for this implementation. Accuracy is checked empirically against exact Jaccard.
-
-`CMinHash.ALGORITHM_VERSION` is **2**. Version 1 used affine maps that produced biased estimates on structured hashes and highly correlated signature slots. Its sorted-successor optimization depended on that faulty construction and has been removed. Version 2 performs O(nk) work, with bounded token batches. **Rebuild existing C-MinHash signatures and indexes from their original tokens:** legacy serialized C-MinHash states are rejected, and old digest arrays must not be mixed with version 2 arrays.
-
-Streaming duplicate checks stop comparing a pair once its remaining signature slots cannot meet the threshold.
-
-`CMinHashDeduplicator` builds an exact candidate index after 128 stored entries. If the threshold permits `d` mismatching signature slots, it partitions the signature into `d + 1` disjoint bands: every accepted duplicate must match at least one complete band. Candidates still pass the same signature comparison, so hash collisions only cause extra checks. This accelerates insertion and boolean duplicate checks at the cost of additional memory proportional to stored entries times band count. Singleton buckets stay inline. Collections initially use a scan, and thresholds requiring at most one matching slot always use a scan. `get_duplicates()` retains its full scan.
+Choose a Hugging Face dataset, the column to deduplicate, a split and the MinHash
+implementation, then run the notebook. It reports how many rows remain and shows
+removed samples alongside the records they matched, so you can inspect what the
+deduplicator considered a duplicate.
 
 ## Installation
 
@@ -77,209 +144,42 @@ Streaming duplicate checks stop comparing a pair once its remaining signature sl
 uv add rensa
 ```
 
-Works on Linux, macOS, and Windows. Python >= 3.8.
-
 ## Usage
 
-### Computing similarity
+### Estimate similarity
 
 ```python
 from rensa import RMinHash
 
-m1 = RMinHash(num_perm=128, seed=42)
-m1.update("the quick brown fox jumps over the lazy dog".split())
-
-m2 = RMinHash(num_perm=128, seed=42)
-m2.update("the quick brown fox jumps over the lazy cat".split())
-
-print(m1.jaccard(m2))  # ~0.78
-```
-
-`CMinHash` has the same interface. Just swap the class name.
-
-### Deduplicating a dataset
-
-```python
-from datasets import load_dataset
-from rensa import RMinHash, RMinHashLSH
-
-dataset = load_dataset("gretelai/synthetic_text_to_sql")["train"]
-
-# Build MinHash signatures
-minhashes = {}
-for idx, row in enumerate(dataset):
-    m = RMinHash(num_perm=128, seed=42)
-    m.update(row["sql"].split())
-    minhashes[idx] = m
-
-# Index into LSH
-lsh = RMinHashLSH(threshold=0.8, num_perm=128, num_bands=16)
-for doc_id, mh in minhashes.items():
-    lsh.insert(doc_id, mh)
-
-# Find and remove duplicates
-to_remove = set()
-for doc_id, mh in minhashes.items():
-    if doc_id in to_remove:
-        continue
-    for candidate in lsh.query(mh):
-        if candidate != doc_id and candidate not in to_remove:
-            if mh.jaccard(minhashes[candidate]) >= 0.85:
-                to_remove.add(max(doc_id, candidate))
-
-print(f"Removed {len(to_remove)} duplicates from {len(dataset)} rows")
-```
-
-### Batch APIs
-
-For large batches, build and query in bulk to reduce Python call overhead:
-
-```python
-from rensa import RMinHash, RMinHashLSH, RMinHashDeduplicator
-
-token_sets = [
-    "select id from users".split(),
-    "select name from users".split(),
-    "select id from users".split(),
-]
-keys = [f"doc-{idx}" for idx in range(len(token_sets))]
-
-minhashes = RMinHash.from_token_sets(token_sets, num_perm=128, seed=42)
-digests = RMinHash.digests_from_token_sets(token_sets, num_perm=128, seed=42)
-
-lsh = RMinHashLSH(threshold=0.8, num_perm=128, num_bands=8)
-lsh.insert_pairs(enumerate(minhashes))
-candidates_per_doc = lsh.query_all(minhashes)
-
-dedup = RMinHashDeduplicator(threshold=0.8, num_perm=128, use_lsh=True, num_bands=8)
-added_flags = dedup.add_pairs(zip(keys, minhashes))
-is_dup_flags = dedup.is_duplicate_pairs(zip(keys, minhashes))
-duplicate_sets = dedup.get_duplicate_sets(minhashes)
-```
-
-`CMinHash` supports the same batch constructors, plus `digests64_from_token_sets(...)`.
-
-For expert throughput paths (when you already have hashed tokens or byte tokens):
-
-```python
-from rensa import CMinHash, RMinHash
-
-token_sets = [
-    "select id from users".split(),
-    "select name from users".split(),
-]
-token_hash_sets = RMinHash.hash_token_sets(token_sets)
-
-r_matrix = RMinHash.digest_matrix_from_token_hash_sets(
-    token_hash_sets, num_perm=128, seed=42
-)
-byte_matrix = RMinHash.digest_matrix_from_token_byte_sets(
-    [[b"alpha", b"beta"], [b"gamma", b"delta"]],
+first, second = RMinHash.from_token_sets(
+    ["the quick brown fox".split(), "the quick brown dog".split()],
     num_perm=128,
     seed=42,
 )
-c_digests64 = CMinHash.digests64_from_token_hash_sets(
-    token_hash_sets, num_perm=128, seed=42
-)
+print(first.jaccard(second))
 ```
 
-`RMinHash.digest_matrix_from_flat_token_hashes(values, offsets, num_perm, seed)` accepts flat token hashes and row boundaries. Typed token buffers must contain contiguous native-endian `uint64` values. Large buffers in single-thread mode are read directly while retaining the GIL; parallel processing uses an owned copy. Row offsets are read before acquiring the token buffer.
+Use `update(tokens)` to extend a sketch incrementally. `CMinHash` supports the
+same similarity interface.
 
-### Streaming deduplication
-
-For continuous data streams, use the built-in deduplicator:
+### Keep unique documents
 
 ```python
-from rensa import RMinHash, RMinHashDeduplicator
+from rensa import RMinHashDeduplicator
 
-dedup = RMinHashDeduplicator(threshold=0.8, num_perm=128, use_lsh=True, num_bands=16)
+documents = [
+    "select id from users",
+    "select name from orders",
+    "select id from users",
+]
+dedup = RMinHashDeduplicator(threshold=0.8, num_perm=128, use_lsh=True)
+keep = dedup.add_pairs(
+    (str(i), text.split()) for i, text in enumerate(documents)
+)
 
-for doc in document_stream:
-    mh = RMinHash(num_perm=128, seed=42)
-    mh.update(doc["text"].split())
-
-    if not dedup.is_duplicate(doc["id"], mh):
-        dedup.add(doc["id"], mh)
-        # process unique document
+print(keep)  # [True, True, False]
 ```
 
-## API
-
-### RMinHash / CMinHash
-
-| Method                           | Description                                                |
-| -------------------------------- | ---------------------------------------------------------- |
-| `__init__(num_perm, seed)`       | Create a MinHash with `num_perm` permutations              |
-| `update(items)`                  | Add items (list of strings, bytes, or iterables)           |
-| `jaccard(other)`                 | Estimate Jaccard similarity (requires matching `num_perm` and `seed`) |
-| `digest()`                       | Return the signature as a list of integers                 |
-| `from_token_sets(...)`           | Build many MinHash objects from token iterables            |
-| `digests_from_token_sets(...)`   | Compute many digests in one call                           |
-| `hash_token_sets(...)`           | Hash token sets to reusable `u64` token hashes             |
-| `digest_matrix_from_token_sets(...)` | Build compact row-major digest matrix                  |
-| `digest_matrix_from_token_hash_sets(...)` | Build compact digest matrix from pre-hashed `u64` tokens |
-| `digest_matrix_from_token_byte_sets(...)` | Build compact digest matrix from bytes-like tokens |
-| `digests64_from_token_sets(...)` | `CMinHash` only, returns `u64`-precision digests           |
-| `digests64_from_token_hash_sets(...)` | `CMinHash` only, uses pre-hashed `u64` tokens         |
-
-### RMinHashLSH
-
-| Method                                     | Description                                                    |
-| ------------------------------------------ | -------------------------------------------------------------- |
-| `__init__(threshold, num_perm, num_bands)` | Create an LSH index. `num_bands` must divide `num_perm` evenly |
-| `insert(key, minhash)`                     | Add a document to the index                                    |
-| `query(minhash)`                           | Return candidate similar document keys                         |
-| `remove(key)`                              | Remove a document from the index                               |
-| `insert_pairs(entries)`                    | Insert many `(key, minhash)` pairs                             |
-| `insert_many(minhashes, start_key=0)`      | Insert many `minhashes` with sequential keys                   |
-| `query_all(minhashes)`                     | Query many minhashes in one call                               |
-| `query_duplicate_flags(minhashes)`         | Return `len(query(minhash)) > 1` flags for many minhashes      |
-
-### RMinHashDeduplicator / CMinHashDeduplicator
-
-| Method                                                               | Description                                 |
-| -------------------------------------------------------------------- | ------------------------------------------- |
-| `RMinHashDeduplicator(threshold, num_perm, use_lsh, num_bands=None, seed=42)` | R-MinHash streaming deduplicator            |
-| `CMinHashDeduplicator(threshold, num_perm=None, seed=42)`           | C-MinHash streaming deduplicator            |
-| `add(key, minhash) -> bool`                                          | Add if unique, returns whether it was added |
-| `is_duplicate(key, minhash) -> bool`                                 | Check without adding                        |
-| `get_duplicates(minhash) -> list[str]`                               | Find keys of similar stored items           |
-| `remove(key)` / `clear()`                                            | Manage stored items                         |
-| `add_pairs(entries) -> list[bool]`                                   | Batch add `(key, minhash)` or `(key, token_set)` pairs |
-| `is_duplicate_pairs(entries) -> list[bool]`                          | Batch duplicate checks for minhash or token-set pairs  |
-| `get_duplicate_sets(minhashes) -> list[list[str]]`                   | Batch duplicate candidate lookup (minhash or token-set inputs) |
-
-## Running Benchmarks
-
-```bash
-git clone https://github.com/beowolx/rensa.git && cd rensa
-uv venv && uv sync --group bench --no-install-project
-uv run maturin develop --release
-uv run python benchmarks/simple_benchmark.py
-```
-
-Run the full cross-library benchmark (single-thread + multi-thread lanes):
-
-```bash
-uv run python benchmarks/full_benchmark.py
-```
-
-`benchmarks/` contains these scripts:
-
-- `benchmarks/simple_benchmark.py`: single-thread quick comparison across Datasketch, FastSketch, R-MinHash, and C-MinHash.
-- `benchmarks/full_benchmark.py`: fair per-run process-isolated benchmark (all engines per subprocess, randomized order) across Datasketch, FastSketch, and Rensa on the full dataset preset suite.
-- `benchmarks/kernel_benchmark.py`: deterministic Rensa-only timings for token hashing, classic and rho sketching, streaming C-MinHash insertion, and duplicate queries, with exact output hashes for comparing builds. For example: `RAYON_NUM_THREADS=1 uv run python benchmarks/kernel_benchmark.py --output-json .bench/kernels.json`.
-- `benchmarks/sketch_benchmark.py`: batch sketch construction on identical byte tokens across classic R-MinHash, C-MinHash, rho, Datasketch and FastSketch. Input preparation and digest normalization are outside timing. Use `--prehashed --sizes 0 1 8 128 4096 65536 1048576 --num-perm 128 512` to compare the R-MinHash and FastSketch flat-buffer APIs through million-token rows; input size is capped by reducing the row count. Add `--repeat-cardinality 4` to measure repeated inputs.
-- `benchmarks/accuracy_benchmark.py`: bias, RMSE and threshold classification against exact Jaccard, plus separate query-all retrieval precision/recall on aligned and reordered pairs. For example: `uv run python benchmarks/accuracy_benchmark.py --output-json .bench/accuracy.json`.
-
-Kernel measurements run each case, input size, and permutation count in a fresh subprocess by default, with 200 ms of untimed warmup and at least 100 ms per sample. Use `--in-process` only for diagnosis. For noisy multi-thread measurements, increase `--min-sample-seconds` and alternate the order of the builds. Keep all samples; large timing dispersion makes a comparison inconclusive.
-
-`simple_benchmark.py` times `rensa_c`, but excludes it from accuracy comparisons because `CMinHashDeduplicator.add_pairs` uses streaming add-if-unique semantics rather than batch query-all semantics.
-
-## Contributing
-
-Contributions welcome, just open a PR or issue.
-
-## License
-
-MIT
+The deduplicator keeps its index across calls, so the same API works for batches
+and streams. LSH candidate retrieval is approximate; the deduplicator checks
+candidates against the sketch similarity threshold.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Rensa (Swedish for "clean") computes MinHash signatures for similarity estimatio
 
 It ships two MinHash variants:
 
-- **R-MinHash**: Rensa's own variant. Very close to datasketch output, fastest option.
-- **C-MinHash**: Based on the [C-MinHash paper](https://arxiv.org/abs/2109.03337). Slightly different results, backed by formal variance proofs.
+- **R-MinHash**: Full-set MinHash with SIMD multiply-shift permutations and 32-bit signature slots.
+- **C-MinHash**: A practical approximation of [circulant MinHash](https://proceedings.mlr.press/v162/li22m.html), with 64-bit signature slots and nonlinear permutations.
+
+The separate **rho batch path** samples token positions to accelerate duplicate detection. Its recall depends on document length and token order, so its speed should be evaluated together with retrieval accuracy. Use the classic full-set APIs when you need order-invariant Jaccard estimates.
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1o1nzwXWAa8kdkEJljbJFW1VuI-3VZLUn?usp=sharing) &nbsp; Thanks [mlabonne](https://github.com/mlabonne) for the Colab notebook!
 
@@ -63,9 +65,11 @@ The global allocator is MiMalloc, which handles the batch-allocate-then-free pat
 
 ### C-MinHash
 
-Rensa also includes C-MinHash, based on the [C-MinHash paper](https://arxiv.org/abs/2109.03337). It uses a two-stage scheme (sigma then pi) that reduces the need for k independent permutations by deriving the k slots from a small parameter set. In this implementation, that means `sigma_a/sigma_b` and `pi_c/pi_d`, with precomputed pi terms for speed. The paper proves tighter variance bounds than standard MinHash. In practice, both variants produce similar results and R-MinHash is usually a bit faster. Use R-MinHash unless you have a specific reason not to.
+Rensa follows the input rotation in Algorithm 3 of Xiaoyun Li and Ping Li's [C-MinHash paper](https://proceedings.mlr.press/v162/li22m/li22m.pdf): `h[k] = min(pi(sigma(x) - (k + 1)))`, with subtraction modulo 2^64. Two separately seeded [SplitMix64 finalizers](https://prng.di.unimi.it/splitmix64.c) provide nonlinear bijections over token hashes. These are compact pseudorandom approximations; the paper's unbiasedness and lower-variance proofs assume uniformly random permutation vectors and do not establish those guarantees for this implementation. Accuracy is checked empirically against exact Jaccard.
 
-For batches with at least 128 tokens and 128 permutations, C-MinHash sorts the transformed token values and finds the minimum for each wrapping offset by binary search. This produces the same signature with O(n log n + k log n) work instead of O(nk), using an additional 8-byte temporary value per token. Streaming duplicate checks stop comparing a pair once its remaining signature slots cannot meet the threshold.
+`CMinHash.ALGORITHM_VERSION` is **2**. Version 1 used affine maps that produced biased estimates on structured hashes and highly correlated signature slots. Its sorted-successor optimization depended on that faulty construction and has been removed. Version 2 performs O(nk) work, with bounded token batches. **Rebuild existing C-MinHash signatures and indexes from their original tokens:** legacy serialized C-MinHash states are rejected, and old digest arrays must not be mixed with version 2 arrays. R-MinHash signatures are unchanged.
+
+Streaming duplicate checks stop comparing a pair once its remaining signature slots cannot meet the threshold.
 
 `CMinHashDeduplicator` builds an exact candidate index after 128 stored entries. If the threshold permits `d` mismatching signature slots, it partitions the signature into `d + 1` disjoint bands: every accepted duplicate must match at least one complete band. Candidates still pass the same signature comparison, so hash collisions only cause extra checks. This accelerates insertion and boolean duplicate checks at the cost of additional memory proportional to stored entries times band count. Singleton buckets stay inline. Collections initially use a scan, and thresholds requiring at most one matching slot always use a scan. `get_duplicates()` retains its full scan.
 
@@ -265,6 +269,8 @@ uv run python benchmarks/full_benchmark.py
 - `benchmarks/simple_benchmark.py`: single-thread quick comparison across Datasketch, FastSketch, R-MinHash, and C-MinHash.
 - `benchmarks/full_benchmark.py`: fair per-run process-isolated benchmark (all engines per subprocess, randomized order) across Datasketch, FastSketch, and Rensa on the full dataset preset suite.
 - `benchmarks/kernel_benchmark.py`: deterministic Rensa-only timings for token hashing, classic and rho sketching, streaming C-MinHash insertion, and duplicate queries, with exact output hashes for comparing builds. For example: `RAYON_NUM_THREADS=1 uv run python benchmarks/kernel_benchmark.py --output-json .bench/kernels.json`.
+- `benchmarks/sketch_benchmark.py`: batch sketch construction on identical byte tokens across classic R-MinHash, C-MinHash, rho, Datasketch and FastSketch. Input preparation and digest normalization are outside timing.
+- `benchmarks/accuracy_benchmark.py`: bias, RMSE and threshold classification against exact Jaccard, plus separate query-all retrieval precision/recall on aligned and reordered pairs. For example: `uv run python benchmarks/accuracy_benchmark.py --output-json .bench/accuracy.json`.
 
 Kernel measurements run each case, input size, and permutation count in a fresh subprocess by default, with 200 ms of untimed warmup and at least 100 ms per sample. Use `--in-process` only for diagnosis. For noisy multi-thread measurements, increase `--min-sample-seconds` and alternate the order of the builds. Keep all samples; large timing dispersion makes a comparison inconclusive.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rensa (Swedish for "clean") computes MinHash signatures for similarity estimatio
 
 It ships two MinHash variants:
 
-- **R-MinHash**: Full-set MinHash with SIMD multiply-shift permutations and 32-bit signature slots.
+- **R-MinHash**: Full-set similarity sketching with seeded bucket rounds, a SIMD fallback, and 32-bit signature slots.
 - **C-MinHash**: A practical approximation of [circulant MinHash](https://proceedings.mlr.press/v162/li22m.html), with 64-bit signature slots and nonlinear permutations.
 
 The separate **rho batch path** samples token positions to accelerate duplicate detection. Its recall depends on document length and token order, so its speed should be evaluated together with retrieval accuracy. Use the classic full-set APIs when you need order-invariant Jaccard estimates.
@@ -35,31 +35,29 @@ These agreement metrics are from the same full benchmark run as the speed number
 
 ## How R-MinHash works
 
-MinHash estimates Jaccard similarity between sets. Apply k random hash functions to a set, keep the minimum value from each. Two sets sharing many elements will produce similar minimums, and the fraction of matching slots estimates the Jaccard index.
+MinHash estimates Jaccard similarity from the fraction of matching signature slots. R-MinHash version 2 uses every input token and a fixed family of hash functions for each `(num_perm, seed)`. Reordering tokens, repeating tokens, or dividing them across incremental updates produces the same signature.
 
-Standard implementations generate each permutation as `(a * hash(x) + b) mod p`, where p is a large prime (typically the Mersenne prime 2^61 - 1). Mathematically clean, but modular reduction is still more expensive than a simple bit shift on modern CPUs.
+The sketch uses three seeded bucket rounds. In each round, a token's hash chooses one of the `num_perm` slots and a rank within that round. Each slot keeps its smallest rank, with earlier rounds taking priority. For a nonempty set, any slot left empty after these rounds receives the actual minimum of its own separately seeded fallback hash over all tokens in the set. Fallback values are computed from tokens, not copied from another bucket. Taking the minimum across updates preserves the same result as processing their union at once.
 
-R-MinHash replaces the modular reduction with **multiply-shift hashing**:
+This is a practical variant of [Fast Similarity Sketching](https://arxiv.org/abs/1704.04370), truncated to a fixed number of bucket rounds before fallback. It uses SplitMix64 mixing for bucket selection and nonlinear mixing followed by seeded affine multiply-shift hashes for fallback. These are approximations to fully random hash functions; the published algorithm's concentration and expected-time guarantees are not established for this variant. Rensa checks its bias, estimation error, and retrieval accuracy against exact Jaccard in `benchmarks/accuracy_benchmark.py`.
 
-```
-signature[i] = min { (a[i] * hash(x) + b[i]) >> 32 }  for all x in set
-```
+Each `u32` slot stores a 2-bit round tag and a 30-bit rank. At 128 slots, the signature values occupy 512 bytes, excluding object and allocation overhead.
 
-Instead of reducing mod a prime, take the upper 32 bits of the 64-bit multiply-add. This is a proven universal hash family ([Dietzfelbinger et al., 1997](https://doi.org/10.1006/jagm.1997.0873)). In R-MinHash, it is used as a practical approximation that keeps deduplication results very close to datasketch in benchmarks while making the hot path cheaper.
-
-This choice has a useful side effect: since the output is naturally 32 bits, signatures are stored as `u32` — 4 bytes per slot instead of 8. For 128 permutations, that's 512 bytes per signature. Half the memory, and twice as many signature slots fit in a cache line.
+`RMinHash.ALGORITHM_VERSION` is **2**. **Rebuild existing R-MinHash signatures and LSH indexes from their original tokens:** legacy serialized sketches and indexes are rejected, and raw digest arrays from different algorithm versions must not be mixed. The separate rho representation is not interchangeable with an R-MinHash signature.
 
 ### Performance engineering
 
 On top of the algorithm, Rensa applies several low-level optimizations.
 
-Input elements are hashed with a fast non-cryptographic hash that mirrors `rustc_hash::FxHasher` semantics while avoiding trait dispatch in the hot path. MinHash needs uniform distribution, not collision resistance, so there's no reason to pay for a cryptographic hash function.
+Input elements are hashed with a fast non-cryptographic hash that mirrors `rustc_hash::FxHasher` semantics while avoiding trait dispatch in the hot path. The sketch then applies its seeded mixing stages to these token hashes.
 
-Elements are hashed in groups of 32. Permutations are applied to each batch in chunks of 16, using a fixed-size temporary array (`[u32; 16]`) that is register-friendly. This gives the compiler room to optimize tight loops and keeps working data cache-local.
+Dense inputs often fill every slot during the bucket rounds, allowing the kernel to skip fallback work. When many slots need fallback, a SIMD kernel evaluates the same fallback hashes together; when few remain, only those slots are evaluated. These paths change how the fixed hash family is evaluated, so short and long documents remain comparable and incremental updates preserve their meaning.
 
-The (a, b) permutation pairs are deterministic, derived from a seed via Xoshiro256++. They are initialized at construction and reused across updates to avoid recomputing setup state on every incremental update. Permutation tables are shared process-wide per `(num_perm, seed)`, so constructing or cloning many `RMinHash` objects with the same parameters costs O(1) in `num_perm`.
+Fallback coefficients are deterministic, derived from a seed via Xoshiro256++, and reused across updates. Their tables and SIMD layouts are shared process-wide per `(num_perm, seed)` to avoid repeated parameter setup. Constructing or cloning a sketch still requires O(`num_perm`) work to allocate or copy its signature values.
 
-Token extraction reads compact ASCII `str` data inline (the common case for tokenized text) instead of round-tripping through `PyUnicode_AsUTF8AndSize`. For batch sketching over lists of ASCII/bytes tokens, worker threads read list items and string payloads directly from CPython object memory (safe because the calling thread holds the GIL and never runs Python during the build), so extraction itself is parallelized instead of bottlenecking on one producer thread; rows containing other token types fall back to the GIL thread. One-shot LSH deduplication groups rows by raw band hashes with intrusive chains (no per-bucket allocations), refines fold windows by exact hash-pair equality, and reuses the same scans' collision counts for its recall-rescue pass, with band scans fanned out across threads when a Rayon pool is available.
+Token extraction reads compact ASCII `str` data inline (the common case for tokenized text) instead of round-tripping through `PyUnicode_AsUTF8AndSize`.
+
+The separate rho batch path can parallelize extraction for lists of ASCII/bytes tokens: worker threads read list items and string payloads directly from CPython object memory while the calling thread holds the GIL and runs no Python callbacks. Rows containing other token types fall back to the GIL thread. Rho's one-shot LSH deduplication groups rows by raw band hashes with intrusive chains, refines fold windows by exact hash-pair equality, and reuses collision counts for its recall-rescue pass. Band scans run in parallel when a Rayon pool is available.
 
 The global allocator is MiMalloc, which handles the batch-allocate-then-free pattern better than the system default. Rensa disables MiMalloc's eager arena commit at module load (unless overridden via `MIMALLOC_ARENA_EAGER_COMMIT`), which keeps peak RSS flat when many threads allocate short-lived sketch buffers.
 
@@ -67,7 +65,7 @@ The global allocator is MiMalloc, which handles the batch-allocate-then-free pat
 
 Rensa follows the input rotation in Algorithm 3 of Xiaoyun Li and Ping Li's [C-MinHash paper](https://proceedings.mlr.press/v162/li22m/li22m.pdf): `h[k] = min(pi(sigma(x) - (k + 1)))`, with subtraction modulo 2^64. Two separately seeded [SplitMix64 finalizers](https://prng.di.unimi.it/splitmix64.c) provide nonlinear bijections over token hashes. These are compact pseudorandom approximations; the paper's unbiasedness and lower-variance proofs assume uniformly random permutation vectors and do not establish those guarantees for this implementation. Accuracy is checked empirically against exact Jaccard.
 
-`CMinHash.ALGORITHM_VERSION` is **2**. Version 1 used affine maps that produced biased estimates on structured hashes and highly correlated signature slots. Its sorted-successor optimization depended on that faulty construction and has been removed. Version 2 performs O(nk) work, with bounded token batches. **Rebuild existing C-MinHash signatures and indexes from their original tokens:** legacy serialized C-MinHash states are rejected, and old digest arrays must not be mixed with version 2 arrays. R-MinHash signatures are unchanged.
+`CMinHash.ALGORITHM_VERSION` is **2**. Version 1 used affine maps that produced biased estimates on structured hashes and highly correlated signature slots. Its sorted-successor optimization depended on that faulty construction and has been removed. Version 2 performs O(nk) work, with bounded token batches. **Rebuild existing C-MinHash signatures and indexes from their original tokens:** legacy serialized C-MinHash states are rejected, and old digest arrays must not be mixed with version 2 arrays.
 
 Streaming duplicate checks stop comparing a pair once its remaining signature slots cannot meet the threshold.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Rensa
 
-High-performance MinHash in Rust with Python bindings. On a reference full benchmark suite, Rensa is 608.52x faster than datasketch and 11.92x faster than FastSketch, with near-identical results.
+High-performance MinHash in Rust with Python bindings, with SIMD sketching and batch deduplication APIs.
 
 ## What is Rensa?
 
-Rensa (Swedish for "clean") computes MinHash signatures for similarity estimation and deduplication. If you need to find near-duplicates in large datasets, Rensa does what datasketch does, much faster.
+Rensa (Swedish for "clean") computes MinHash signatures for similarity estimation and deduplication, including approximate batch processing for finding near-duplicates in large datasets.
 
 It ships two MinHash variants:
 
@@ -15,7 +15,7 @@ It ships two MinHash variants:
 
 ## Performance
 
-Numbers below come from a reference full benchmark run (`benchmarks/full_benchmark.py`) over 7 datasets and 2 thread lanes (`threads=1,8`), 128 permutations, threshold 0.8, and 8 bands.
+The historical reference run below used `benchmarks/full_benchmark.py` over 7 datasets and 2 thread lanes (`threads=1,8`), 128 permutations, threshold 0.8, and 8 bands. Its raw results, hardware details, and dependency versions are not checked in, so these figures should not be treated as a verified comparison of current releases.
 
 ![Deduplication speed: full benchmark suite](./assets/bench_time_full_suite.png)
 
@@ -24,7 +24,7 @@ Numbers below come from a reference full benchmark run (`benchmarks/full_benchma
 | **Rensa vs Datasketch** | **608.52x faster** |
 | **Rensa vs FastSketch** | **11.92x faster** |
 
-| Accuracy vs Datasketch | Value |
+| Agreement vs Datasketch | Value |
 | ---------------------- | ----- |
 | Mean Jaccard of kept sets | 0.987219 |
 | Mean duplicate-flag mismatch rate | 0.010717 |

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ c_digests64 = CMinHash.digests64_from_token_hash_sets(
 )
 ```
 
+`RMinHash.digest_matrix_from_flat_token_hashes(values, offsets, num_perm, seed)` accepts flat token hashes and row boundaries. Typed token buffers must contain contiguous native-endian `uint64` values. Large buffers in single-thread mode are read directly while retaining the GIL; parallel processing uses an owned copy. Row offsets are read before acquiring the token buffer.
+
 ### Streaming deduplication
 
 For continuous data streams, use the built-in deduplicator:
@@ -267,7 +269,7 @@ uv run python benchmarks/full_benchmark.py
 - `benchmarks/simple_benchmark.py`: single-thread quick comparison across Datasketch, FastSketch, R-MinHash, and C-MinHash.
 - `benchmarks/full_benchmark.py`: fair per-run process-isolated benchmark (all engines per subprocess, randomized order) across Datasketch, FastSketch, and Rensa on the full dataset preset suite.
 - `benchmarks/kernel_benchmark.py`: deterministic Rensa-only timings for token hashing, classic and rho sketching, streaming C-MinHash insertion, and duplicate queries, with exact output hashes for comparing builds. For example: `RAYON_NUM_THREADS=1 uv run python benchmarks/kernel_benchmark.py --output-json .bench/kernels.json`.
-- `benchmarks/sketch_benchmark.py`: batch sketch construction on identical byte tokens across classic R-MinHash, C-MinHash, rho, Datasketch and FastSketch. Input preparation and digest normalization are outside timing.
+- `benchmarks/sketch_benchmark.py`: batch sketch construction on identical byte tokens across classic R-MinHash, C-MinHash, rho, Datasketch and FastSketch. Input preparation and digest normalization are outside timing. Use `--prehashed --sizes 0 1 8 128 4096 65536 1048576 --num-perm 128 512` to compare the R-MinHash and FastSketch flat-buffer APIs through million-token rows; input size is capped by reducing the row count. Add `--repeat-cardinality 4` to measure repeated inputs.
 - `benchmarks/accuracy_benchmark.py`: bias, RMSE and threshold classification against exact Jaccard, plus separate query-all retrieval precision/recall on aligned and reordered pairs. For example: `uv run python benchmarks/accuracy_benchmark.py --output-json .bench/accuracy.json`.
 
 Kernel measurements run each case, input size, and permutation count in a fresh subprocess by default, with 200 ms of untimed warmup and at least 100 ms per sample. Use `--in-process` only for diagnosis. For noisy multi-thread measurements, increase `--min-sample-seconds` and alternate the order of the builds. Keep all samples; large timing dispersion makes a comparison inconclusive.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The global allocator is MiMalloc, which handles the batch-allocate-then-free pat
 
 Rensa also includes C-MinHash, based on the [C-MinHash paper](https://arxiv.org/abs/2109.03337). It uses a two-stage scheme (sigma then pi) that reduces the need for k independent permutations by deriving the k slots from a small parameter set. In this implementation, that means `sigma_a/sigma_b` and `pi_c/pi_d`, with precomputed pi terms for speed. The paper proves tighter variance bounds than standard MinHash. In practice, both variants produce similar results and R-MinHash is usually a bit faster. Use R-MinHash unless you have a specific reason not to.
 
+For batches with at least 128 tokens and 128 permutations, C-MinHash sorts the transformed token values and finds the minimum for each wrapping offset by binary search. This produces the same signature with O(n log n + k log n) work instead of O(nk), using an additional 8-byte temporary value per token. Streaming duplicate checks stop comparing a pair once its remaining signature slots cannot meet the threshold.
+
 ## Installation
 
 ```bash
@@ -203,7 +205,7 @@ for doc in document_stream:
 | -------------------------------- | ---------------------------------------------------------- |
 | `__init__(num_perm, seed)`       | Create a MinHash with `num_perm` permutations              |
 | `update(items)`                  | Add items (list of strings, bytes, or iterables)           |
-| `jaccard(other)`                 | Estimate Jaccard similarity (requires matching `num_perm`) |
+| `jaccard(other)`                 | Estimate Jaccard similarity (requires matching `num_perm` and `seed`) |
 | `digest()`                       | Return the signature as a list of integers                 |
 | `from_token_sets(...)`           | Build many MinHash objects from token iterables            |
 | `digests_from_token_sets(...)`   | Compute many digests in one call                           |

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ uv run python benchmarks/full_benchmark.py
 - `benchmarks/full_benchmark.py`: fair per-run process-isolated benchmark (all engines per subprocess, randomized order) across Datasketch, FastSketch, and Rensa on the full dataset preset suite.
 - `benchmarks/kernel_benchmark.py`: deterministic Rensa-only timings for token hashing, classic and rho sketching, streaming C-MinHash insertion, and duplicate queries, with exact output hashes for comparing builds. For example: `RAYON_NUM_THREADS=1 uv run python benchmarks/kernel_benchmark.py --output-json .bench/kernels.json`.
 
-Kernel measurements default to 200 ms of untimed warmup and at least 100 ms per sample. For noisy multi-thread measurements, run individual cases in fresh processes using `--cases`, `--sizes`, and `--num-perm`, increase `--min-sample-seconds`, and alternate the order of the builds. Keep all samples; large timing dispersion makes a comparison inconclusive.
+Kernel measurements run each case, input size, and permutation count in a fresh subprocess by default, with 200 ms of untimed warmup and at least 100 ms per sample. Use `--in-process` only for diagnosis. For noisy multi-thread measurements, increase `--min-sample-seconds` and alternate the order of the builds. Keep all samples; large timing dispersion makes a comparison inconclusive.
 
 `simple_benchmark.py` times `rensa_c`, but excludes it from accuracy comparisons because `CMinHashDeduplicator.add_pairs` uses streaming add-if-unique semantics rather than batch query-all semantics.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Numbers below come from a reference full benchmark run (`benchmarks/full_benchma
 | Mean Jaccard of kept sets | 0.987219 |
 | Mean duplicate-flag mismatch rate | 0.010717 |
 
-These accuracy metrics are from the same full benchmark run as the speed numbers above.
+These agreement metrics are from the same full benchmark run as the speed numbers above. They compare duplicate decisions with Datasketch, not with exact Jaccard ground truth. The benchmark uses Rensa’s approximate rho matrix and one-shot duplicate flags. Current FastSketchLSH also uses its fused duplicate-flag API; older versions fall back to candidate lists, as does Datasketch. The speedups describe these deduplication pipelines, not every MinHash API or workload.
 
 ## How R-MinHash works
 
@@ -256,11 +256,11 @@ Run the full cross-library benchmark (single-thread + multi-thread lanes):
 uv run python benchmarks/full_benchmark.py
 ```
 
-`benchmarks/` now contains three scripts:
+`benchmarks/` contains these scripts:
 
 - `benchmarks/simple_benchmark.py`: single-thread quick comparison across Datasketch, FastSketch, R-MinHash, and C-MinHash.
 - `benchmarks/full_benchmark.py`: fair per-run process-isolated benchmark (all engines per subprocess, randomized order) across Datasketch, FastSketch, and Rensa on the full dataset preset suite.
-- `benchmarks/perf_memory_benchmark.py`: Rensa-only time and peak-memory (VmHWM/VmRSS, Linux) benchmark on a deterministic synthetic corpus with injected duplicates, per thread lane and per phase (sketch / dedup / classic update path), with duplicate-flag precision/recall as an accuracy guardrail. Use `--label` to tag runs and compare JSON outputs across code changes.
+- `benchmarks/kernel_benchmark.py`: deterministic Rensa-only timings for classic sketching, rho sketching, and duplicate queries, with exact output hashes for comparing builds. For example: `RAYON_NUM_THREADS=1 uv run python benchmarks/kernel_benchmark.py --output-json .bench/kernels.json`.
 
 `simple_benchmark.py` times `rensa_c`, but excludes it from accuracy comparisons because `CMinHashDeduplicator.add_pairs` uses streaming add-if-unique semantics rather than batch query-all semantics.
 

--- a/benchmarks/accuracy_benchmark.py
+++ b/benchmarks/accuracy_benchmark.py
@@ -1,0 +1,204 @@
+"""Compare sketch error and retrieval against exact Jaccard, without downloads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import random
+import statistics
+from collections import defaultdict
+from importlib.metadata import version
+from pathlib import Path
+
+for name in ("RAYON_NUM_THREADS", "OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ[name] = "1"
+
+import numpy as np
+from datasketch import MinHash, MinHashLSH
+from FastSketchLSH import FastSimilaritySketch, LSH, estimate_jaccard
+from rensa import CMinHash, RMinHash, RMinHashLSH
+
+
+def pairs(sizes, targets, repeats, orders):
+    rows, cases = [], []
+    rng = random.Random(20260905)
+    for size in sizes:
+        seen_overlaps = set()
+        for target in targets:
+            overlap = round(2 * size * target / (1 + target))
+            if overlap in seen_overlaps:
+                continue
+            seen_overlaps.add(overlap)
+            for order in orders:
+                for repeat in range(repeats):
+                    prefix = f"pair-{len(cases)}-"
+                    common = [f"{prefix}shared-{i}" for i in range(overlap)]
+                    left = common + [f"{prefix}left-{i}" for i in range(size - overlap)]
+                    right = common + [f"{prefix}right-{i}" for i in range(size - overlap)]
+                    if order == "shuffled":
+                        rng.shuffle(left)
+                        rng.shuffle(right)
+                    elif order == "reversed":
+                        right.reverse()
+                    left_set, right_set = set(left), set(right)
+                    exact = len(left_set & right_set) / len(left_set | right_set)
+                    cases.append({"size": size, "target": target, "order": order,
+                                  "repeat": repeat, "exact": exact})
+                    rows.extend([left, right])
+    return rows, cases
+
+
+def sketch(engine, rows, k, seed):
+    if engine == "rensa_classic":
+        matrix = RMinHash.digest_matrix_from_token_sets(rows, k, seed)
+        return np.asarray(matrix.to_rows(), dtype=np.uint64), matrix
+    if engine == "rensa_c":
+        return np.asarray(CMinHash.digests64_from_token_sets(rows, k, seed), dtype=np.uint64), None
+    if engine == "datasketch":
+        hashes = list(MinHash.generator(([token.encode() for token in row] for row in rows),
+                                      num_perm=k, seed=seed))
+        return np.asarray([mh.hashvalues for mh in hashes]), hashes
+    if engine == "fastsketch":
+        matrix = FastSimilaritySketch(k, seed=seed).batch(rows, num_threads=1)
+        assert estimate_jaccard(matrix[0], matrix[1]) == float(np.mean(matrix[0] == matrix[1]))
+        return matrix, matrix
+    if engine == "rensa_rho":
+        matrix = RMinHash.digest_matrix_from_token_sets_rho(rows, k, seed)
+        return None, matrix
+    raise ValueError(engine)
+
+
+def summarize(estimates, exacts, k, threshold):
+    errors = [estimate - exact for estimate, exact in zip(estimates, exacts)]
+    bias = statistics.mean(errors)
+    mse = statistics.mean(value * value for value in errors)
+    reference_mse = statistics.mean(j * (1 - j) / k for j in exacts)
+    return {"count": len(errors), "bias": bias, "rmse": math.sqrt(mse),
+            "mae": statistics.mean(abs(value) for value in errors),
+            "error_variance": statistics.pvariance(errors),
+            "bias_standard_error": statistics.pstdev(errors) / math.sqrt(len(errors)),
+            "ideal_independent_minhash_rmse": math.sqrt(reference_mse),
+            "mse_over_ideal_minhash": mse / reference_mse if reference_mse else None,
+            "threshold_classification": confusion(
+                [j >= threshold for j in exacts],
+                [estimate >= threshold for estimate in estimates])}
+
+
+def accuracy(args):
+    rows, cases = pairs(args.sizes, [0, .25, .5, .75, .79, .81, .9, 1],
+                       args.repeats, ["shuffled"])
+    result = {}
+    for k in args.perms:
+        for engine in args.engines:
+            all_estimates, exacts = [], []
+            grouped = defaultdict(lambda: ([], []))
+            for seed in range(args.seeds):
+                matrix, _ = sketch(engine, rows, k, seed)
+                estimates = np.mean(matrix[0::2] == matrix[1::2], axis=1)
+                for case, estimated in zip(cases, estimates):
+                    all_estimates.append(float(estimated))
+                    exacts.append(case["exact"])
+                    cell = grouped[f'n={case["size"]},j={case["exact"]:.6f}']
+                    cell[0].append(float(estimated))
+                    cell[1].append(case["exact"])
+            result[f"{engine}/k={k}"] = {
+                **summarize(all_estimates, exacts, k, args.threshold),
+                "by_case": {key: summarize(*values, k, args.threshold)
+                            for key, values in grouped.items()}}
+            print(f"accuracy {engine} k={k}: RMSE={result[f'{engine}/k={k}']['rmse']:.6f}", flush=True)
+    return result
+
+
+def confusion(truth, predicted):
+    tp = sum(a and b for a, b in zip(truth, predicted))
+    tn = sum(not a and not b for a, b in zip(truth, predicted))
+    fp = sum(not a and b for a, b in zip(truth, predicted))
+    fn = sum(a and not b for a, b in zip(truth, predicted))
+    return {"tp": tp, "tn": tn, "fp": fp, "fn": fn,
+            "precision": tp / (tp + fp) if tp + fp else None,
+            "recall": tp / (tp + fn) if tp + fn else None,
+            "false_positive_rate": fp / (fp + tn) if fp + tn else None}
+
+
+def retrieval(args):
+    rows, cases = pairs(args.sizes, [0, .5, .7, .79, .81, .9, 1], args.repeats,
+                       ["aligned", "shuffled", "reversed"])
+    row_cases = [case for case in cases for _ in range(2)]
+    truth = [case["exact"] >= args.threshold for case in row_cases]
+    result = {}
+    k = 128
+    for engine in ["rensa_classic", "rensa_rho", "datasketch", "fastsketch"]:
+        actual, all_truth = [], []
+        grouped = defaultdict(lambda: ([], []))
+        for seed in range(args.retrieval_seeds):
+            matrix, native = sketch(engine, rows, k, seed)
+            if engine in ("rensa_classic", "rensa_rho"):
+                index = RMinHashLSH(threshold=args.threshold, num_perm=k, num_bands=8)
+                flags = list(index.query_duplicate_flags_matrix_one_shot(native))
+            elif engine == "datasketch":
+                index = MinHashLSH(num_perm=k, params=(8, 16))
+                for i, signature in enumerate(native):
+                    index.insert(i, signature, check_duplication=False)
+                flags = [any(candidate != i for candidate in index.query(signature))
+                         for i, signature in enumerate(native)]
+            elif engine == "fastsketch":
+                index = LSH(num_perm=k, num_bands=8, num_threads=1)
+                flags = list(index.insert_and_query_duplicates(matrix))
+            flags = [bool(flag) for flag in flags]
+            actual.extend(flags)
+            all_truth.extend(truth)
+            for expected, flag, case in zip(truth, flags, row_cases):
+                key = f'n={case["size"]},j={case["exact"]:.6f},order={case["order"]}'
+                grouped[key][0].append(expected)
+                grouped[key][1].append(flag)
+        result[engine] = {**confusion(all_truth, actual),
+                          "by_case": {key: confusion(*values) for key, values in grouped.items()}}
+        print(f"retrieval {engine}: {confusion(all_truth, actual)}", flush=True)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--sizes", type=int, nargs="+", default=[2, 16, 128, 1024])
+    parser.add_argument("--perms", type=int, nargs="+", default=[128, 512])
+    parser.add_argument("--seeds", type=int, default=8)
+    parser.add_argument("--repeats", type=int, default=8)
+    parser.add_argument("--retrieval-seeds", type=int, default=4)
+    parser.add_argument("--threshold", type=float, default=.8)
+    parser.add_argument("--engines", nargs="+", choices=["rensa_classic", "rensa_c", "datasketch", "fastsketch"],
+                        default=["rensa_classic", "rensa_c", "datasketch", "fastsketch"])
+    parser.add_argument("--skip-retrieval", action="store_true")
+    args = parser.parse_args()
+    if min(*args.sizes, *args.perms, args.seeds, args.repeats, args.retrieval_seeds) < 1:
+        parser.error("sizes, permutations, seeds and repeats must be positive")
+    if not 0 <= args.threshold <= 1:
+        parser.error("threshold must be between zero and one")
+    payload = {"config": {key: str(value) if isinstance(value, Path) else value
+                           for key, value in vars(args).items()},
+               "versions": {name: version(name) for name in ("rensa", "datasketch", "FastSketchLSH")},
+               "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", 1),
+               "environment": {key: value for key, value in sorted(os.environ.items())
+                               if key.startswith(("RENSA_", "RAYON_"))},
+               "retrieval_config": {"num_perm": 128, "num_bands": 8},
+               "notes": ["Ground truth is exact intersection/union on string sets.",
+                         "Different pair namespaces make non-mate pairs exactly disjoint.",
+                         "All sketches use identical token lists and the same number of signature slots.",
+                         "C-MinHash/FastSketch slots are 64-bit; classic/Datasketch slots have 32-bit values.",
+                         "Rho is only evaluated as a retrieval pipeline, not as a slot-equality Jaccard estimator.",
+                         "Datasketch and FastSketch retrieval are unverified 8-band/16-row candidates.",
+                         "Threshold classification compares all four full-signature engines using the same estimate >= threshold rule.",
+                         "C streaming removal semantics differ from query-all retrieval and are excluded from the retrieval section.",
+                         "Retrieval counts rows having another row above the exact threshold; both members of a matching pair are positives.",
+                         "Standard errors are descriptive; seeded trials share input pairs and are not a rigorous confidence interval."]}
+    payload["accuracy"] = accuracy(args)
+    if not args.skip_retrieval:
+        payload["retrieval"] = retrieval(args)
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/accuracy_benchmark.py
+++ b/benchmarks/accuracy_benchmark.py
@@ -180,6 +180,7 @@ def main():
                            for key, value in vars(args).items()},
                "versions": {name: version(name) for name in ("rensa", "datasketch", "FastSketchLSH")},
                "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", 1),
+               "rminhash_algorithm_version": getattr(RMinHash, "ALGORITHM_VERSION", 1),
                "environment": {key: value for key, value in sorted(os.environ.items())
                                if key.startswith(("RENSA_", "RAYON_"))},
                "retrieval_config": {"num_perm": 128, "num_bands": 8},

--- a/benchmarks/full_benchmark.py
+++ b/benchmarks/full_benchmark.py
@@ -17,9 +17,6 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, Mapping
 
-from datasets import load_dataset
-from datasketch import MinHash, MinHashLSH
-
 THREAD_ENV_VARS = (
     "OMP_NUM_THREADS",
     "RAYON_NUM_THREADS",
@@ -321,6 +318,8 @@ def load_token_sets_from_hf(
     max_rows: int | None,
     ngram_size: int,
 ) -> list[list[str]]:
+    from datasets import load_dataset
+
     load_kwargs: dict[str, Any] = {"split": spec.split}
     if spec.revision:
         load_kwargs["revision"] = spec.revision
@@ -406,6 +405,8 @@ def run_datasketch(
     threshold: float,
     seed: int,
 ) -> tuple[dict[str, Any], list[bool]]:
+    from datasketch import MinHash, MinHashLSH
+
     rows_per_band = num_perm // num_bands
     _ = threshold  # `params=(b, r)` controls banding for datasketch in this benchmark.
 
@@ -467,26 +468,35 @@ def run_fastsketch(
 ) -> tuple[dict[str, Any], list[bool]]:
     from FastSketchLSH import FastSimilaritySketch, LSH  # type: ignore
 
-    sketcher = FastSimilaritySketch(sketch_size=num_perm, seed=seed)
+    sketcher = FastSimilaritySketch(num_perm, seed=seed)
 
     sketch_start = perf_counter()
-    sketches = sketcher.sketch_batch(token_sets, num_threads=threads)
+    batch = sketcher.batch if hasattr(sketcher, "batch") else sketcher.sketch_batch
+    sketches = batch(token_sets, num_threads=threads)
     sketch_elapsed = perf_counter() - sketch_start
 
     lsh = LSH(num_perm=num_perm, num_bands=num_bands, num_threads=threads)
 
+    total_candidates: int | None = None
+    query_elapsed = 0.0
     build_start = perf_counter()
-    lsh.build_from_batch(sketches)
-    build_elapsed = perf_counter() - build_start
+    if hasattr(lsh, "insert_and_query_duplicates"):
+        duplicate_flags = [bool(value) for value in lsh.insert_and_query_duplicates(sketches)]
+        build_elapsed = perf_counter() - build_start
+    else:
+        # Compatibility with FastSketchLSH 0.2 in older benchmark environments.
+        lsh.build_from_batch(sketches)
+        build_elapsed = perf_counter() - build_start
 
-    query_start = perf_counter()
-    flat, indptr = lsh.batch_query_csr(sketches)
-    row_count = len(indptr) - 1
-    duplicate_flags = [
-        int(indptr[index + 1] - indptr[index]) > 1 for index in range(row_count)
-    ]
-    query_elapsed = perf_counter() - query_start
+        query_start = perf_counter()
+        flat, indptr = lsh.batch_query_csr(sketches)
+        duplicate_flags = [
+            int(indptr[index + 1] - indptr[index]) > 1 for index in range(len(indptr) - 1)
+        ]
+        query_elapsed = perf_counter() - query_start
+        total_candidates = int(len(flat))
 
+    row_count = len(duplicate_flags)
     rows_removed = sum(1 for is_duplicate in duplicate_flags if is_duplicate)
     metrics = {
         "sketch": sketch_elapsed,
@@ -495,8 +505,10 @@ def run_fastsketch(
         "total": sketch_elapsed + build_elapsed + query_elapsed,
         "rows_removed": rows_removed,
         "rows_remaining": row_count - rows_removed,
-        "total_candidates": int(len(flat)),
-        "avg_candidates_per_row": (len(flat) / row_count) if row_count else 0.0,
+        "total_candidates": total_candidates,
+        "avg_candidates_per_row": (
+            (total_candidates / row_count) if row_count else 0.0
+        ) if total_candidates is not None else None,
     }
     return metrics, duplicate_flags
 
@@ -721,6 +733,10 @@ def run_once(args: argparse.Namespace) -> None:
         "token_cache_sha256": token_cache_sha,
         "thread_env_assertions": thread_assertions,
         "engines": results,
+        "duplicate_flags_sha256": {
+            engine: hashlib.sha256(bytes(flags)).hexdigest()
+            for engine, flags in flags_by_engine.items()
+        },
         "accuracy": {
             "jaccard": {
                 "datasketch_vs_rensa": jaccard_similarity(

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Deterministic, stdlib-only Rensa kernels; run the same file against both wheels.
+
+Times include returned-object allocation, but exclude input generation, digest
+extraction, correctness hashing, and result destruction. Update cases include
+construction of fresh sketches. Query cases exclude index construction.
+"""
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import statistics
+import subprocess
+import time
+from pathlib import Path
+
+from rensa import CMinHash, RMinHash, RMinHashLSH
+
+CASES = (
+    "r_update", "c_update", "r_batch", "r_prehashed", "c_prehashed",
+    "rho", "rho_dedup", "query",
+)
+
+
+def fingerprint(value):
+    return hashlib.sha256(
+        json.dumps(value, separators=(",", ":")).encode("ascii")
+    ).hexdigest()
+
+
+def cpu_name():
+    if platform.system() == "Darwin":
+        result = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"], text=True, capture_output=True
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.exists():
+        for line in cpuinfo.read_text().splitlines():
+            if line.startswith("model name"):
+                return line.partition(":")[2].strip()
+    return platform.processor() or platform.machine()
+
+
+def documents(rows, size):
+    # Each consecutive group of four contains one exact duplicate pair and
+    # two disjoint documents. Strings, row order, and overlap are reproducible.
+    return [
+        [f"document-{row - (row % 4 == 1)}-token-{token}" for token in range(size)]
+        for row in range(rows)
+    ]
+
+
+def update_all(cls, docs, num_perm, seed):
+    sketches = []
+    for doc in docs:
+        sketch = cls(num_perm, seed)
+        sketch.update(doc)
+        sketches.append(sketch)
+    return sketches
+
+
+def operation(case, docs, hashes, num_perm, seed):
+    if case in ("r_update", "c_update"):
+        cls = RMinHash if case == "r_update" else CMinHash
+        extract = (lambda result: [s.digest() for s in result]) if case == "r_update" else (
+            lambda result: [s.digest_u64() for s in result]
+        )
+        return lambda: update_all(cls, docs, num_perm, seed), extract
+    if case == "c_prehashed":
+        return lambda: CMinHash.digests64_from_token_hash_sets(hashes, num_perm, seed), lambda x: x
+    if case == "query":
+        sketches = RMinHash.from_token_sets(docs, num_perm, seed)
+        index = RMinHashLSH(0.5, num_perm, 16)
+        index.insert_many(sketches)
+        return lambda: index.query_duplicate_flags(sketches), lambda x: x
+    if case == "rho_dedup":
+        def run():
+            matrix = RMinHash.digest_matrix_from_token_sets_rho(docs, num_perm, seed)
+            index = RMinHashLSH(0.5, num_perm, 16)
+            flags = index.query_duplicate_flags_matrix_one_shot(matrix)
+            return matrix, flags
+        return run, lambda result: [result[0].to_rows(), result[1]]
+    method, values = {
+        "r_batch": (RMinHash.digest_matrix_from_token_sets, docs),
+        "r_prehashed": (RMinHash.digest_matrix_from_token_hash_sets, hashes),
+        "rho": (RMinHash.digest_matrix_from_token_sets_rho, docs),
+    }[case]
+    return lambda: method(values, num_perm, seed), lambda result: result.to_rows()
+
+
+def measure(run, extract, repetitions, min_sample_seconds):
+    result = run()  # Warm caches, lazy SIMD dispatch, and Rayon initialization.
+    expected = fingerprint(extract(result))
+    del result
+    samples = []
+    iterations = []
+    for _ in range(repetitions):
+        elapsed = 0.0
+        count = 0
+        while elapsed < min_sample_seconds or count == 0:
+            if count:
+                del result
+            start = time.perf_counter_ns()
+            result = run()
+            elapsed += (time.perf_counter_ns() - start) / 1e9
+            count += 1
+        samples.append(elapsed / count)
+        iterations.append(count)
+        if fingerprint(extract(result)) != expected:
+            raise RuntimeError("Non-deterministic output across repetitions")
+        del result
+    return {"seconds": samples, "iterations": iterations, "median_seconds": statistics.median(samples), "sha256": expected}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--rows", type=int, default=512)
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument("--min-sample-seconds", type=float, default=0.02)
+    parser.add_argument("--sizes", type=int, nargs="+", default=[1, 8, 32, 128, 1024, 4096])
+    parser.add_argument("--num-perm", type=int, nargs="+", default=[128, 512])
+    parser.add_argument("--cases", choices=CASES, nargs="+", default=list(CASES))
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+    if min(args.rows, args.repetitions, *args.sizes, *args.num_perm) <= 0:
+        parser.error("rows, repetitions, sizes, and num-perm must be positive")
+    if not 0 <= args.min_sample_seconds < float("inf"):
+        parser.error("min-sample-seconds must be finite and nonnegative")
+    if any(n % 16 for n in args.num_perm) and any(case in args.cases for case in ("query", "rho_dedup")):
+        parser.error("num-perm must divide evenly into the fixed 16-band LSH")
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    report = {
+        "schema_version": 1,
+        "environment": {
+            "platform": platform.platform(), "machine": platform.machine(),
+            "cpu": cpu_name(), "logical_cpus": os.cpu_count(),
+            "python": platform.python_version(), "rensa": importlib.metadata.version("rensa"),
+            "flags": {key: value for key, value in sorted(os.environ.items())
+                      if key.startswith(("RENSA_", "RAYON_")) or key in ("RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS")},
+        },
+        "config": {key: value for key, value in vars(args).items() if key != "output_json"},
+        "results": [],
+    }
+    for size in args.sizes:
+        docs = documents(args.rows, size)
+        hashes = RMinHash.hash_token_sets(docs)
+        for num_perm in args.num_perm:
+            checksums = {}
+            for case in args.cases:
+                run, extract = operation(case, docs, hashes, num_perm, args.seed)
+                result = measure(run, extract, args.repetitions, args.min_sample_seconds)
+                checksums[case] = result["sha256"]
+                result.update(case=case, tokens_per_row=size, num_perm=num_perm)
+                report["results"].append(result)
+                print(f"{case:12s} tokens={size:4d} perm={num_perm:3d}: {result['median_seconds']:.6f}s", flush=True)
+            for equivalent in (("r_update", "r_batch", "r_prehashed"), ("c_update", "c_prehashed")):
+                if len({checksums[name] for name in equivalent if name in checksums}) > 1:
+                    raise RuntimeError(f"Digest mismatch among equivalent APIs: {equivalent}")
+        args.output_json.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from rensa import CMinHash, RMinHash, RMinHashLSH
 
 CASES = (
-    "r_update", "c_update", "r_batch", "r_prehashed", "c_prehashed",
+    "hash", "r_update", "c_update", "r_batch", "r_prehashed", "c_prehashed",
     "rho", "rho_dedup", "query",
 )
 
@@ -65,6 +65,8 @@ def update_all(cls, docs, num_perm, seed):
 
 
 def operation(case, docs, hashes, num_perm, seed):
+    if case == "hash":
+        return lambda: RMinHash.hash_token_sets(docs), lambda result: result
     if case in ("r_update", "c_update"):
         cls = RMinHash if case == "r_update" else CMinHash
         extract = (lambda result: [s.digest() for s in result]) if case == "r_update" else (

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -74,7 +74,7 @@ def operation(case, docs, hashes, num_perm, seed):
             index = CMinHashDeduplicator(0.8, num_perm, seed)
             flags = index.add_pairs(entries)
             return index, flags
-        return insert, lambda result: [len(result[0]), result[1]]
+        return insert, lambda result: [result[0].len(), result[1]]
     if case in ("r_update", "c_update"):
         cls = RMinHash if case == "r_update" else CMinHash
         extract = (lambda result: [s.digest() for s in result]) if case == "r_update" else (

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -14,6 +14,8 @@ import os
 import platform
 import statistics
 import subprocess
+import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -133,6 +135,25 @@ def measure(run, extract, repetitions, min_sample_seconds, warmup_seconds):
     return {"seconds": samples, "iterations": iterations, "median_seconds": statistics.median(samples), "sha256": expected}
 
 
+def isolated_case(args, case, size, num_perm):
+    with tempfile.TemporaryDirectory(prefix="rensa-kernel-") as directory:
+        output = Path(directory) / "result.json"
+        command = [
+            sys.executable, str(Path(__file__).resolve()), "--in-process",
+            "--output-json", str(output), "--cases", case, "--sizes", str(size),
+            "--num-perm", str(num_perm),
+        ]
+        for name in ("rows", "repetitions", "min_sample_seconds", "warmup_seconds", "seed"):
+            command.extend(["--" + name.replace("_", "-"), str(getattr(args, name))])
+        completed = subprocess.run(command, text=True, capture_output=True)
+        if completed.returncode:
+            raise RuntimeError(
+                f"Kernel subprocess failed ({case}, tokens={size}, perm={num_perm}):\n"
+                f"{completed.stderr}\n{completed.stdout}"
+            )
+        return json.loads(output.read_text())["results"][0]
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-json", type=Path, required=True)
@@ -144,6 +165,8 @@ def main():
     parser.add_argument("--num-perm", type=int, nargs="+", default=[128, 512])
     parser.add_argument("--cases", choices=CASES, nargs="+", default=list(CASES))
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--in-process", action="store_true",
+                        help="Run cases together for internal execution or diagnosis.")
     args = parser.parse_args()
     if min(args.rows, args.repetitions, *args.sizes, *args.num_perm) <= 0:
         parser.error("rows, repetitions, sizes, and num-perm must be positive")
@@ -167,13 +190,17 @@ def main():
         "results": [],
     }
     for size in args.sizes:
-        docs = documents(args.rows, size)
-        hashes = RMinHash.hash_token_sets(docs)
+        if args.in_process:
+            docs = documents(args.rows, size)
+            hashes = RMinHash.hash_token_sets(docs)
         for num_perm in args.num_perm:
             checksums = {}
             for case in args.cases:
-                run, extract = operation(case, docs, hashes, num_perm, args.seed)
-                result = measure(run, extract, args.repetitions, args.min_sample_seconds, args.warmup_seconds)
+                if args.in_process:
+                    run, extract = operation(case, docs, hashes, num_perm, args.seed)
+                    result = measure(run, extract, args.repetitions, args.min_sample_seconds, args.warmup_seconds)
+                else:
+                    result = isolated_case(args, case, size, num_perm)
                 checksums[case] = result["sha256"]
                 result.update(case=case, tokens_per_row=size, num_perm=num_perm)
                 report["results"].append(result)

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -142,8 +142,7 @@ def measure(run, extract, repetitions, min_sample_seconds, warmup_seconds):
         elapsed = 0.0
         count = 0
         while elapsed < min_sample_seconds or count == 0:
-            if count:
-                del result
+            result = None
             start = time.perf_counter_ns()
             result = run()
             elapsed += (time.perf_counter_ns() - start) / 1e9

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -183,6 +183,7 @@ def main():
             "platform": platform.platform(), "machine": platform.machine(),
             "cpu": cpu_name(), "logical_cpus": os.cpu_count(),
             "python": platform.python_version(), "rensa": importlib.metadata.version("rensa"),
+            "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", 1),
             "flags": {key: value for key, value in sorted(os.environ.items())
                       if key.startswith(("RENSA_", "RAYON_")) or key in ("RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS")},
         },

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -8,6 +8,7 @@ construction of fresh sketches. Query cases exclude index construction.
 
 import argparse
 import hashlib
+import importlib.machinery
 import importlib.metadata
 import json
 import os
@@ -46,6 +47,26 @@ def cpu_name():
             if line.startswith("model name"):
                 return line.partition(":")[2].strip()
     return platform.processor() or platform.machine()
+
+
+def cpu_flags():
+    """Report OS-advertised CPU features, not the binary's selected kernel."""
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.exists():
+        for line in cpuinfo.read_text().splitlines():
+            name, _, value = line.partition(":")
+            if name.strip() in ("flags", "Features"):
+                return sorted(value.split())
+    return None
+
+
+def native_binary_sha256(distribution_name):
+    distribution = importlib.metadata.distribution(distribution_name)
+    return {
+        str(path): hashlib.sha256(distribution.locate_file(path).read_bytes()).hexdigest()
+        for path in distribution.files or ()
+        if str(path).endswith(tuple(importlib.machinery.EXTENSION_SUFFIXES))
+    }
 
 
 def documents(rows, size):
@@ -182,6 +203,8 @@ def main():
         "environment": {
             "platform": platform.platform(), "machine": platform.machine(),
             "cpu": cpu_name(), "logical_cpus": os.cpu_count(),
+            "cpu_flags": cpu_flags(),
+            "native_binary_sha256": {"rensa": native_binary_sha256("rensa")},
             "python": platform.python_version(), "rensa": importlib.metadata.version("rensa"),
             "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", 1),
             "rminhash_algorithm_version": getattr(RMinHash, "ALGORITHM_VERSION", 1),

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -17,11 +17,11 @@ import subprocess
 import time
 from pathlib import Path
 
-from rensa import CMinHash, RMinHash, RMinHashLSH
+from rensa import CMinHash, CMinHashDeduplicator, RMinHash, RMinHashLSH
 
 CASES = (
     "hash", "r_update", "c_update", "r_batch", "r_prehashed", "c_prehashed",
-    "rho", "rho_dedup", "query",
+    "rho", "rho_dedup", "c_dedup", "query",
 )
 
 
@@ -67,6 +67,14 @@ def update_all(cls, docs, num_perm, seed):
 def operation(case, docs, hashes, num_perm, seed):
     if case == "hash":
         return lambda: RMinHash.hash_token_sets(docs), lambda result: result
+    if case == "c_dedup":
+        signatures = CMinHash.from_token_sets(docs, num_perm, seed)
+        entries = [(str(index), value) for index, value in enumerate(signatures)]
+        def insert():
+            index = CMinHashDeduplicator(0.8, num_perm, seed)
+            flags = index.add_pairs(entries)
+            return index, flags
+        return insert, lambda result: [len(result[0]), result[1]]
     if case in ("r_update", "c_update"):
         cls = RMinHash if case == "r_update" else CMinHash
         extract = (lambda result: [s.digest() for s in result]) if case == "r_update" else (
@@ -95,9 +103,15 @@ def operation(case, docs, hashes, num_perm, seed):
     return lambda: method(values, num_perm, seed), lambda result: result.to_rows()
 
 
-def measure(run, extract, repetitions, min_sample_seconds):
+def measure(run, extract, repetitions, min_sample_seconds, warmup_seconds):
     result = run()  # Warm caches, lazy SIMD dispatch, and Rayon initialization.
     expected = fingerprint(extract(result))
+    warmup_deadline = time.perf_counter() + warmup_seconds
+    while time.perf_counter() < warmup_deadline:
+        del result
+        result = run()
+    if fingerprint(extract(result)) != expected:
+        raise RuntimeError("Non-deterministic output during warmup")
     del result
     samples = []
     iterations = []
@@ -124,7 +138,8 @@ def main():
     parser.add_argument("--output-json", type=Path, required=True)
     parser.add_argument("--rows", type=int, default=512)
     parser.add_argument("--repetitions", type=int, default=5)
-    parser.add_argument("--min-sample-seconds", type=float, default=0.02)
+    parser.add_argument("--min-sample-seconds", type=float, default=0.1)
+    parser.add_argument("--warmup-seconds", type=float, default=0.2)
     parser.add_argument("--sizes", type=int, nargs="+", default=[1, 8, 32, 128, 1024, 4096])
     parser.add_argument("--num-perm", type=int, nargs="+", default=[128, 512])
     parser.add_argument("--cases", choices=CASES, nargs="+", default=list(CASES))
@@ -132,6 +147,8 @@ def main():
     args = parser.parse_args()
     if min(args.rows, args.repetitions, *args.sizes, *args.num_perm) <= 0:
         parser.error("rows, repetitions, sizes, and num-perm must be positive")
+    if not 0 <= args.warmup_seconds < float("inf"):
+        parser.error("warmup-seconds must be finite and nonnegative")
     if not 0 <= args.min_sample_seconds < float("inf"):
         parser.error("min-sample-seconds must be finite and nonnegative")
     if any(n % 16 for n in args.num_perm) and any(case in args.cases for case in ("query", "rho_dedup")):
@@ -156,7 +173,7 @@ def main():
             checksums = {}
             for case in args.cases:
                 run, extract = operation(case, docs, hashes, num_perm, args.seed)
-                result = measure(run, extract, args.repetitions, args.min_sample_seconds)
+                result = measure(run, extract, args.repetitions, args.min_sample_seconds, args.warmup_seconds)
                 checksums[case] = result["sha256"]
                 result.update(case=case, tokens_per_row=size, num_perm=num_perm)
                 report["results"].append(result)

--- a/benchmarks/kernel_benchmark.py
+++ b/benchmarks/kernel_benchmark.py
@@ -184,6 +184,7 @@ def main():
             "cpu": cpu_name(), "logical_cpus": os.cpu_count(),
             "python": platform.python_version(), "rensa": importlib.metadata.version("rensa"),
             "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", 1),
+            "rminhash_algorithm_version": getattr(RMinHash, "ALGORITHM_VERSION", 1),
             "flags": {key: value for key, value in sorted(os.environ.items())
                       if key.startswith(("RENSA_", "RAYON_")) or key in ("RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS")},
         },

--- a/benchmarks/paired_sketch_benchmark.py
+++ b/benchmarks/paired_sketch_benchmark.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Compare frozen R-MinHash builds in alternating intervals on identical inputs.
+
+This is an additional diagnostic, with no performance thresholds. Both native
+extensions stay loaded in one process; FastSketch is an unchanged timing control.
+"""
+
+import argparse
+import importlib.machinery
+import importlib.metadata
+import importlib.util
+import json
+import os
+import platform
+import statistics
+from pathlib import Path
+
+# This import sets thread limits before initializing NumPy or native libraries.
+from sketch_benchmark import THREAD_ENV, inputs, operation
+from full_benchmark import sha256_file
+from kernel_benchmark import cpu_flags, cpu_name, measure, native_binary_sha256
+
+
+def load_extensions(base_path, head_path):
+    if base_path.samefile(head_path):
+        raise ValueError("base and head must be separate native extension files")
+    modules = {}
+    metadata = {}
+    for name, path in (("base", base_path), ("head", head_path)):
+        spec = importlib.util.spec_from_file_location(f"{name}.rensa", path)
+        if spec is None or not isinstance(spec.loader, importlib.machinery.ExtensionFileLoader):
+            raise ValueError(f"not a native extension file: {path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        modules[name] = module
+        metadata[name] = {
+            "path": str(path.resolve()), "sha256": sha256_file(path),
+            "algorithm_version": getattr(module.RMinHash, "ALGORITHM_VERSION", 1),
+            "version": getattr(module, "__version__", None),
+        }
+    if modules["base"].RMinHash is modules["head"].RMinHash:
+        raise ValueError("base and head resolved to the same RMinHash class")
+    if metadata["base"]["algorithm_version"] != metadata["head"]["algorithm_version"]:
+        raise ValueError("paired comparison requires the same R-MinHash algorithm version")
+    return modules, metadata
+
+
+def native_operation(module, rows, num_perm, seed, prehashed):
+    # Bind the frozen class directly; the shared helper uses the installed class.
+    method = (module.RMinHash.digest_matrix_from_flat_token_hashes if prehashed
+              else module.RMinHash.digest_matrix_from_token_sets)
+    values = rows if prehashed else (rows,)
+    return lambda: method(*values, num_perm, seed), lambda result: result.to_rows()
+
+
+def paired_measure(operations, repetitions, min_sample_seconds, warmup_seconds):
+    samples = {}
+    for engine, (run, extract) in operations.items():
+        warmed = measure(run, extract, 1, 0, warmup_seconds)
+        samples[engine] = {"seconds": [], "iterations": [], "sha256": warmed["sha256"]}
+    if samples["base"]["sha256"] != samples["head"]["sha256"]:
+        raise RuntimeError("Base/head signatures differ")
+
+    # AB/BA alternates every cycle; FastSketch rotates through all three slots.
+    orders = (
+        ("base", "head", "fastsketch"), ("head", "base", "fastsketch"),
+        ("fastsketch", "base", "head"), ("fastsketch", "head", "base"),
+        ("base", "fastsketch", "head"), ("head", "fastsketch", "base"),
+    )
+    engine_order = []
+    for cycle in range(repetitions):
+        order = orders[cycle % len(orders)]
+        engine_order.append(order)
+        for engine in order:
+            run, extract = operations[engine]
+            result = measure(run, extract, 1, min_sample_seconds, 0)
+            if result["sha256"] != samples[engine]["sha256"]:
+                raise RuntimeError(f"{engine} signatures changed in paired cycle {cycle}")
+            samples[engine]["seconds"].extend(result["seconds"])
+            samples[engine]["iterations"].extend(result["iterations"])
+    for result in samples.values():
+        result["median_seconds"] = statistics.median(result["seconds"])
+    head_over_base = [h / b for b, h in zip(samples["base"]["seconds"], samples["head"]["seconds"])]
+    fastsketch_over_head = [f / h for f, h in zip(samples["fastsketch"]["seconds"], samples["head"]["seconds"])]
+    return {
+        "engine_order": engine_order, "samples": samples,
+        "paired_head_over_base": head_over_base,
+        "paired_fastsketch_over_head": fastsketch_over_head,
+        "median_paired_head_over_base": statistics.median(head_over_base),
+        "median_paired_fastsketch_over_head": statistics.median(fastsketch_over_head),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-extension", type=Path, required=True)
+    parser.add_argument("--head-extension", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--prehashed", action="store_true")
+    parser.add_argument("--sizes", type=int, nargs="+", default=[8, 128, 4096])
+    parser.add_argument("--num-perm", type=int, nargs="+", default=[128, 512])
+    parser.add_argument("--rows", type=int, default=256)
+    parser.add_argument("--max-input-tokens", type=int, default=8_388_608)
+    parser.add_argument("--repeat-cardinality", type=int)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--repetitions", type=int, default=6)
+    parser.add_argument("--min-sample-seconds", type=float, default=0.1)
+    parser.add_argument("--warmup-seconds", type=float, default=0.2)
+    args = parser.parse_args()
+    if min(args.rows, args.max_input_tokens, args.repetitions, *args.num_perm) <= 0 or min(args.sizes) < 0:
+        parser.error("rows, token budget, repetitions and num-perm must be positive; sizes must be nonnegative")
+    if max(args.sizes) > args.max_input_tokens:
+        parser.error("a row cannot exceed max-input-tokens")
+    if any(k & (k - 1) or k > 4096 for k in args.num_perm):
+        parser.error("FastSketch requires power-of-two num-perm no greater than 4096")
+    if not args.prehashed and 0 in args.sizes:
+        parser.error("FastSketch's byte API rejects empty rows; use prehashed mode")
+    if args.repeat_cardinality is not None and (not args.prehashed or args.repeat_cardinality <= 0):
+        parser.error("repeat-cardinality requires prehashed mode and a positive value")
+    if not 0 <= args.seed <= 2**32 - 1:
+        parser.error("seed must fit the shared unsigned 32-bit seed range")
+    if not all(0 <= value < float("inf") for value in (args.min_sample_seconds, args.warmup_seconds)):
+        parser.error("sample and warmup durations must be finite and nonnegative")
+    try:
+        modules, extensions = load_extensions(args.base_extension, args.head_extension)
+    except (OSError, ImportError, ValueError) as error:
+        parser.error(str(error))
+
+    report = {
+        "schema_version": 1, "extensions": extensions,
+        "environment": {
+            "platform": platform.platform(), "python": platform.python_version(),
+            "cpu": cpu_name(), "cpu_flags": cpu_flags(),
+            "versions": {name: importlib.metadata.version(name) for name in ("FastSketchLSH", "numpy")},
+            "fastsketch_binary_sha256": native_binary_sha256("FastSketchLSH"),
+            "flags": {key: value for key, value in sorted(os.environ.items())
+                      if key in THREAD_ENV or key.startswith("RENSA_")},
+        },
+        "methodology": {
+            "timed": "Native batch call, internal per-call setup, native output allocation",
+            "excluded": "Input preparation, normalization/checksums, returned-object destruction; reusable FastSketch constructor only in prehashed mode",
+            "order": "Alternating base/head order, with FastSketch position balanced over six cycles",
+            "validation": "Existing normalized JSON fingerprint; exact R signatures and per-engine invariance after warmup and every sample",
+        },
+        "config": {key: value for key, value in vars(args).items()
+                   if key not in ("base_extension", "head_extension", "output_json")},
+        "results": [],
+    }
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    for size in args.sizes:
+        input_args = argparse.Namespace(**vars(args))
+        input_args.token_cache = None
+        input_args.rows = min(args.rows, args.max_input_tokens // max(size, 1))
+        rows, metadata = inputs(input_args, size)
+        for num_perm in args.num_perm:
+            operations = {name: native_operation(module, rows, num_perm, args.seed, args.prehashed)
+                          for name, module in modules.items()}
+            operations["fastsketch"] = operation("fastsketch", rows, num_perm, args.seed, args.prehashed)
+            result = paired_measure(operations, args.repetitions, args.min_sample_seconds, args.warmup_seconds)
+            result.update(metadata, num_perm=num_perm)
+            report["results"].append(result)
+            print(f"tokens={size} k={num_perm}: paired head/base={result['median_paired_head_over_base']:.4f}, "
+                  f"FastSketch/head={result['median_paired_fastsketch_over_head']:.4f}", flush=True)
+            args.output_json.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/simple_benchmark.py
+++ b/benchmarks/simple_benchmark.py
@@ -406,6 +406,7 @@ def main(args: argparse.Namespace) -> None:
             global_max_rows = None
 
     thread_env = pin_single_thread_env()
+    from rensa import CMinHash
 
     spec = DATASET_PRESETS[args.dataset]
     effective_max_rows = resolve_max_rows(spec, global_max_rows=global_max_rows, dataset_max_rows={})
@@ -466,6 +467,7 @@ def main(args: argparse.Namespace) -> None:
             "timestamp_utc": datetime.now(timezone.utc).isoformat(),
             "python_version": platform.python_version(),
             "platform": platform.platform(),
+            "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", 1),
             "library_versions": {
                 "datasketch": resolve_package_version("datasketch"),
                 "datasets": resolve_package_version("datasets"),

--- a/benchmarks/simple_benchmark.py
+++ b/benchmarks/simple_benchmark.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import pickle
@@ -223,6 +224,10 @@ def run_once(
         "rows": len(token_sets),
         "order": order,
         "engines": results,
+        "duplicate_flags_sha256": {
+            engine: hashlib.sha256(bytes(flags)).hexdigest()
+            for engine, flags in flags_by_engine.items()
+        },
         "accuracy": {
             "jaccard": {
                 "datasketch_vs_fastsketch": jaccard_similarity(
@@ -400,6 +405,8 @@ def main(args: argparse.Namespace) -> None:
         if global_max_rows == 0:
             global_max_rows = None
 
+    thread_env = pin_single_thread_env()
+
     spec = DATASET_PRESETS[args.dataset]
     effective_max_rows = resolve_max_rows(spec, global_max_rows=global_max_rows, dataset_max_rows={})
 
@@ -411,8 +418,6 @@ def main(args: argparse.Namespace) -> None:
     )
     with token_cache.open("rb") as handle:
         token_sets: list[list[str]] = pickle.load(handle)
-
-    thread_env = pin_single_thread_env()
 
     print(
         f"Prepared dataset '{spec.key}' rows={row_count} "

--- a/benchmarks/simple_benchmark.py
+++ b/benchmarks/simple_benchmark.py
@@ -406,7 +406,7 @@ def main(args: argparse.Namespace) -> None:
             global_max_rows = None
 
     thread_env = pin_single_thread_env()
-    from rensa import CMinHash
+    from rensa import CMinHash, RMinHash
 
     spec = DATASET_PRESETS[args.dataset]
     effective_max_rows = resolve_max_rows(spec, global_max_rows=global_max_rows, dataset_max_rows={})
@@ -468,6 +468,7 @@ def main(args: argparse.Namespace) -> None:
             "python_version": platform.python_version(),
             "platform": platform.platform(),
             "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", 1),
+            "rminhash_algorithm_version": getattr(RMinHash, "ALGORITHM_VERSION", 1),
             "library_versions": {
                 "datasketch": resolve_package_version("datasketch"),
                 "datasets": resolve_package_version("datasets"),

--- a/benchmarks/sketch_benchmark.py
+++ b/benchmarks/sketch_benchmark.py
@@ -34,7 +34,7 @@ from datasketch import MinHash
 from FastSketchLSH import FastSimilaritySketch
 import numpy as np
 from full_benchmark import sha256_file
-from kernel_benchmark import cpu_name, documents, measure
+from kernel_benchmark import cpu_flags, cpu_name, documents, measure, native_binary_sha256
 from rensa import CMinHash, RMinHash
 
 ENGINES = ("rensa_classic", "rensa_rho", "rensa_c", "datasketch", "fastsketch")
@@ -219,6 +219,9 @@ def main():
         "environment": {
             "platform": platform.platform(), "machine": platform.machine(),
             "cpu": cpu_name(), "python": platform.python_version(),
+            "cpu_flags": cpu_flags(),
+            "native_binary_sha256": {name: native_binary_sha256(name)
+                                     for name in ("rensa", "FastSketchLSH")},
             "versions": {name: importlib.metadata.version(name)
                          for name in ("rensa", "datasketch", "FastSketchLSH", "numpy")},
             "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", None),

--- a/benchmarks/sketch_benchmark.py
+++ b/benchmarks/sketch_benchmark.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Compare native batch sketching on identical UTF-8 bytes, using one thread.
+
+Each engine/size/signature-length case runs in a fresh process. Timing includes
+parameter construction and native returned outputs, but excludes input encoding,
+digest normalization, checksums, and returned-object destruction. Rho is a
+sampled retrieval representation, so its speed needs separate accuracy results.
+"""
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import pickle
+import platform
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Set these before importing libraries that initialize their thread pools.
+THREAD_ENV = (
+    "RAYON_NUM_THREADS", "OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS", "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS",
+)
+for variable in THREAD_ENV:
+    os.environ[variable] = "1"
+
+from datasketch import MinHash
+from FastSketchLSH import FastSimilaritySketch
+from full_benchmark import sha256_file
+from kernel_benchmark import cpu_name, documents, measure
+from rensa import CMinHash, RMinHash
+
+ENGINES = ("rensa_classic", "rensa_rho", "rensa_c", "datasketch", "fastsketch")
+
+
+def inputs(args, size):
+    cache_sha = None
+    if args.token_cache:
+        cache_sha = sha256_file(args.token_cache)
+        with args.token_cache.open("rb") as handle:
+            rows = pickle.load(handle)
+    else:
+        rows = documents(args.rows, size)
+    rows = [
+        [token.encode("utf-8") if isinstance(token, str) else token for token in row]
+        for row in rows
+    ]
+    digest = hashlib.sha256()
+    digest.update(len(rows).to_bytes(8, "little"))
+    for row in rows:
+        digest.update(len(row).to_bytes(8, "little"))
+        for token in row:
+            if not isinstance(token, bytes):
+                raise TypeError("Token caches must contain rows of str or bytes tokens")
+            digest.update(len(token).to_bytes(8, "little"))
+            digest.update(token)
+    return rows, {
+        "rows": len(rows), "tokens": sum(map(len, rows)),
+        "tokens_per_row": size, "input_sha256": digest.hexdigest(),
+        "token_cache": str(args.token_cache) if args.token_cache else None,
+        "token_cache_sha256": cache_sha,
+    }
+
+
+def operation(engine, rows, num_perm, seed):
+    if engine in ("rensa_classic", "rensa_rho"):
+        method = (
+            RMinHash.digest_matrix_from_token_sets if engine == "rensa_classic"
+            else RMinHash.digest_matrix_from_token_sets_rho
+        )
+        return lambda: method(rows, num_perm, seed), lambda result: result.to_rows()
+    if engine == "rensa_c":
+        # Keep signatures native; digests64 would box every slot as a Python int.
+        return (
+            lambda: CMinHash.from_token_sets(rows, num_perm, seed),
+            lambda result: [sketch.digest_u64() for sketch in result],
+        )
+    if engine == "datasketch":
+        return (
+            lambda: list(MinHash.generator(rows, num_perm=num_perm, seed=seed)),
+            lambda result: [sketch.hashvalues.tolist() for sketch in result],
+        )
+
+    def run_fastsketch():
+        sketcher = FastSimilaritySketch(num_perm, seed=seed)
+        result = sketcher.batch(rows, num_threads=1)
+        return sketcher, result  # Destroy both after the timed interval.
+
+    return run_fastsketch, lambda result: result[1].tolist()
+
+
+def isolated_case(args, engine, size, num_perm):
+    with tempfile.TemporaryDirectory(prefix="rensa-sketch-") as directory:
+        output = Path(directory) / "result.json"
+        command = [
+            sys.executable, str(Path(__file__).resolve()), "--in-process",
+            "--output-json", str(output), "--engines", engine,
+            "--num-perm", str(num_perm),
+        ]
+        if args.token_cache:
+            command.extend(["--token-cache", str(args.token_cache)])
+        else:
+            command.extend(["--sizes", str(size)])
+        for name in ("rows", "repetitions", "min_sample_seconds", "warmup_seconds", "seed"):
+            command.extend(["--" + name.replace("_", "-"), str(getattr(args, name))])
+        completed = subprocess.run(command, text=True, capture_output=True)
+        if completed.returncode:
+            raise RuntimeError(
+                f"Sketch subprocess failed ({engine}, tokens={size}, perm={num_perm}):\n"
+                f"{completed.stderr}\n{completed.stdout}"
+            )
+        return json.loads(output.read_text())["results"][0]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--token-cache", type=Path,
+                        help="Existing local token pickle; uses all cached rows, ignoring sizes/rows.")
+    parser.add_argument("--rows", type=int, default=512)
+    parser.add_argument("--sizes", type=int, nargs="+", default=[8, 128, 1024])
+    parser.add_argument("--num-perm", type=int, nargs="+", default=[128])
+    parser.add_argument("--engines", choices=ENGINES, nargs="+", default=list(ENGINES))
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument("--min-sample-seconds", "--min-sample", type=float, default=0.1)
+    parser.add_argument("--warmup-seconds", type=float, default=0.2)
+    parser.add_argument("--in-process", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if min(args.rows, args.repetitions, *args.sizes, *args.num_perm) <= 0:
+        parser.error("rows, repetitions, sizes, and num-perm must be positive")
+    if not 0 <= args.seed <= 2**32 - 1:
+        parser.error("seed must fit the shared unsigned 32-bit seed range")
+    if not all(0 <= value < float("inf") for value in (args.min_sample_seconds, args.warmup_seconds)):
+        parser.error("sample and warmup durations must be finite and nonnegative")
+    report = {
+        "schema_version": 1,
+        "environment": {
+            "platform": platform.platform(), "machine": platform.machine(),
+            "cpu": cpu_name(), "python": platform.python_version(),
+            "versions": {name: importlib.metadata.version(name)
+                         for name in ("rensa", "datasketch", "FastSketchLSH", "numpy")},
+            "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", None),
+            "flags": {key: value for key, value in sorted(os.environ.items())
+                      if key in THREAD_ENV or key.startswith("RENSA_")},
+        },
+        "methodology": {
+            "input": "Identical UTF-8 bytes, same row/token order, no deduplication or sorting",
+            "timed": "Parameter construction, batch sketching, native output allocation",
+            "excluded": "Input preparation, output normalization/checksums, returned-object destruction",
+            "isolation": "fresh process per engine/input/k" if not args.in_process else "single process",
+            "accuracy": "Reported separately; rho uses position sampling and is not a classic MinHash estimator",
+            "validation": "Normalized SHA256 checked after warmup and every measured repetition",
+            "apis": {
+                "rensa_classic": "RMinHash.digest_matrix_from_token_sets",
+                "rensa_rho": "RMinHash.digest_matrix_from_token_sets_rho",
+                "rensa_c": "CMinHash.from_token_sets",
+                "datasketch": "MinHash.generator (fully consumed)",
+                "fastsketch": "FastSimilaritySketch(...).batch(..., num_threads=1)",
+            },
+        },
+        "config": {key: str(value) if isinstance(value, Path) else value
+                   for key, value in vars(args).items() if key != "output_json"},
+        "results": [],
+    }
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    for size in ([None] if args.token_cache else args.sizes):
+        if args.in_process:
+            rows, input_metadata = inputs(args, size)
+        for num_perm in args.num_perm:
+            checksums = set()
+            for engine in args.engines:
+                if args.in_process:
+                    run, extract = operation(engine, rows, num_perm, args.seed)
+                    result = measure(run, extract, args.repetitions, args.min_sample_seconds, args.warmup_seconds)
+                    result.update(input_metadata)
+                else:
+                    result = isolated_case(args, engine, size, num_perm)
+                checksums.add(result["input_sha256"])
+                result.update(engine=engine, num_perm=num_perm)
+                report["results"].append(result)
+                print(f"{engine:14s} rows={result['rows']:5d} tokens={size} perm={num_perm}: "
+                      f"{result['median_seconds']:.6f}s", flush=True)
+            if len(checksums) != 1:
+                raise RuntimeError("Engines did not receive identical input bytes")
+            args.output_json.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/sketch_benchmark.py
+++ b/benchmarks/sketch_benchmark.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Compare native batch sketching on identical UTF-8 bytes, using one thread.
+"""Compare native batch sketching on identical bytes or prehashed CSR inputs.
 
 Each engine/size/signature-length case runs in a fresh process. Timing includes
 parameter construction and native returned outputs, but excludes input encoding,
 digest normalization, checksums, and returned-object destruction. Rho is a
 sampled retrieval representation, so its speed needs separate accuracy results.
+Prehashed mode reuses FastSketch's constructor outside timing and caps input size.
 """
 
 import argparse
@@ -14,6 +15,7 @@ import json
 import os
 import pickle
 import platform
+import random
 import subprocess
 import sys
 import tempfile
@@ -30,6 +32,7 @@ os.environ["RENSA_PIPELINE_QUEUE_CAP"] = "0"
 
 from datasketch import MinHash
 from FastSketchLSH import FastSimilaritySketch
+import numpy as np
 from full_benchmark import sha256_file
 from kernel_benchmark import cpu_name, documents, measure
 from rensa import CMinHash, RMinHash
@@ -37,7 +40,44 @@ from rensa import CMinHash, RMinHash
 ENGINES = ("rensa_classic", "rensa_rho", "rensa_c", "datasketch", "fastsketch")
 
 
+def mixed_sequence(count):
+    # SplitMix's bijective finalizer produces unique, scattered uint64 values.
+    values = np.arange(count, dtype=np.uint64)
+    values += np.uint64(12345 + 0x9E3779B97F4A7C15)
+    values ^= values >> np.uint64(30)
+    values *= np.uint64(0xBF58476D1CE4E5B9)
+    values ^= values >> np.uint64(27)
+    values *= np.uint64(0x94D049BB133111EB)
+    values ^= values >> np.uint64(31)
+    return values
+
+
+def prehashed_inputs(args, size):
+    rows = min(args.rows, args.max_input_tokens // max(size, 1))
+    cardinality = min(size, args.repeat_cardinality or size)
+    if cardinality == size:
+        flat = mixed_sequence(rows * size)
+    else:
+        vocabulary = mixed_sequence(rows * cardinality).reshape(rows, cardinality)
+        flat = np.take(vocabulary, np.arange(size) % cardinality, axis=1).reshape(-1)
+    offsets = np.arange(rows + 1, dtype=np.uint64) * np.uint64(size)
+    flat.flags.writeable = offsets.flags.writeable = False
+    digest = hashlib.sha256(b"rensa-prehashed-csr-v1\0")
+    digest.update(rows.to_bytes(8, "little"))
+    digest.update(size.to_bytes(8, "little"))
+    for values in (flat, offsets):
+        digest.update(memoryview(values.astype("<u8", copy=False)).cast("B"))
+    return (flat, offsets), {
+        "rows": rows, "tokens": rows * size, "tokens_per_row": size,
+        "distinct_tokens_per_row": cardinality,
+        "input_sha256": digest.hexdigest(), "input_bytes": flat.nbytes + offsets.nbytes,
+        "token_cache": None, "token_cache_sha256": None,
+    }
+
+
 def inputs(args, size):
+    if args.prehashed:
+        return prehashed_inputs(args, size)
     cache_sha = None
     if args.token_cache:
         cache_sha = sha256_file(args.token_cache)
@@ -66,7 +106,19 @@ def inputs(args, size):
     }
 
 
-def operation(engine, rows, num_perm, seed):
+def operation(engine, rows, num_perm, seed, prehashed=False):
+    if prehashed:
+        flat, offsets = rows
+        if engine == "rensa_classic":
+            return (
+                lambda: RMinHash.digest_matrix_from_flat_token_hashes(flat, offsets, num_perm, seed),
+                lambda result: result.to_rows(),
+            )
+        sketcher = FastSimilaritySketch(num_perm, seed=seed)
+        return (
+            lambda: sketcher.batch_csr(flat, offsets, prehashed=True, num_threads=1),
+            lambda result: result.tolist(),
+        )
     if engine in ("rensa_classic", "rensa_rho"):
         method = (
             RMinHash.digest_matrix_from_token_sets if engine == "rensa_classic"
@@ -105,7 +157,11 @@ def isolated_case(args, engine, size, num_perm):
             command.extend(["--token-cache", str(args.token_cache)])
         else:
             command.extend(["--sizes", str(size)])
-        for name in ("rows", "repetitions", "min_sample_seconds", "warmup_seconds", "seed"):
+        if args.prehashed:
+            command.append("--prehashed")
+        if args.repeat_cardinality is not None:
+            command.extend(["--repeat-cardinality", str(args.repeat_cardinality)])
+        for name in ("rows", "max_input_tokens", "repetitions", "min_sample_seconds", "warmup_seconds", "seed"):
             command.extend(["--" + name.replace("_", "-"), str(getattr(args, name))])
         completed = subprocess.run(command, text=True, capture_output=True)
         if completed.returncode:
@@ -122,17 +178,36 @@ def main():
     parser.add_argument("--token-cache", type=Path,
                         help="Existing local token pickle; uses all cached rows, ignoring sizes/rows.")
     parser.add_argument("--rows", type=int, default=512)
+    parser.add_argument("--prehashed", action="store_true",
+                        help="Compare Rensa/FastSketch CSR APIs using identical readonly uint64 buffers.")
+    parser.add_argument("--max-input-tokens", type=int, default=8_388_608,
+                        help="Cap prehashed tokens per case by reducing rows for long inputs.")
+    parser.add_argument("--repeat-cardinality", type=int,
+                        help="Repeat this many distinct values per prehashed row; default is all unique.")
     parser.add_argument("--sizes", type=int, nargs="+", default=[8, 128, 1024])
     parser.add_argument("--num-perm", type=int, nargs="+", default=[128])
-    parser.add_argument("--engines", choices=ENGINES, nargs="+", default=list(ENGINES))
+    parser.add_argument("--engines", choices=ENGINES, nargs="+")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--repetitions", type=int, default=5)
     parser.add_argument("--min-sample-seconds", "--min-sample", type=float, default=0.1)
     parser.add_argument("--warmup-seconds", type=float, default=0.2)
     parser.add_argument("--in-process", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
-    if min(args.rows, args.repetitions, *args.sizes, *args.num_perm) <= 0:
-        parser.error("rows, repetitions, sizes, and num-perm must be positive")
+    if args.engines is None:
+        args.engines = ["rensa_classic", "fastsketch"] if args.prehashed else list(ENGINES)
+    if min(args.rows, args.repetitions, args.max_input_tokens, *args.num_perm) <= 0 or min(args.sizes) < 0:
+        parser.error("rows, repetitions, token budget and num-perm must be positive; sizes must be nonnegative")
+    if args.prehashed:
+        if args.token_cache or set(args.engines) - {"rensa_classic", "fastsketch"}:
+            parser.error("prehashed mode supports only Rensa classic and FastSketch, without a token cache")
+        if max(args.sizes) > args.max_input_tokens:
+            parser.error("a prehashed row cannot exceed max-input-tokens")
+    elif args.repeat_cardinality is not None:
+        parser.error("repeat-cardinality requires prehashed mode")
+    if args.repeat_cardinality is not None and args.repeat_cardinality <= 0:
+        parser.error("repeat-cardinality must be positive")
+    if "fastsketch" in args.engines and any(k & (k - 1) or k > 4096 for k in args.num_perm):
+        parser.error("FastSketch requires power-of-two num-perm no greater than 4096")
     if not 0 <= args.seed <= 2**32 - 1:
         parser.error("seed must fit the shared unsigned 32-bit seed range")
     if not all(0 <= value < float("inf") for value in (args.min_sample_seconds, args.warmup_seconds)):
@@ -154,6 +229,7 @@ def main():
             "timed": "Parameter construction, batch sketching, native output allocation",
             "excluded": "Input preparation, output normalization/checksums, returned-object destruction",
             "isolation": "fresh process per engine/input/k" if not args.in_process else "single process",
+            "engine_order": "deterministic shuffle per size/k" if args.prehashed else "configured order",
             "accuracy": "Reported separately; rho uses position sampling and is not a classic MinHash estimator",
             "validation": "Normalized SHA256 checked after warmup and every measured repetition",
             "apis": {
@@ -168,15 +244,26 @@ def main():
                    for key, value in vars(args).items() if key != "output_json"},
         "results": [],
     }
+    if args.prehashed:
+        report["methodology"].update(
+            input="Identical readonly contiguous uint64 values and CSR offsets; SplitMix64 sequence seeded with 12345",
+            timed="Native batch call, internal per-call setup/copies, native output allocation",
+            excluded="Input preparation, reusable FastSketch constructor, output normalization/checksums, returned-object destruction",
+            apis={"rensa_classic": "RMinHash.digest_matrix_from_flat_token_hashes",
+                  "fastsketch": "FastSimilaritySketch(...).batch_csr(..., prehashed=True, num_threads=1)"},
+        )
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
     for size in ([None] if args.token_cache else args.sizes):
         if args.in_process:
             rows, input_metadata = inputs(args, size)
         for num_perm in args.num_perm:
             checksums = set()
-            for engine in args.engines:
+            engines = list(args.engines)
+            if args.prehashed:
+                random.Random(f"{args.seed}:{size}:{num_perm}").shuffle(engines)
+            for engine in engines:
                 if args.in_process:
-                    run, extract = operation(engine, rows, num_perm, args.seed)
+                    run, extract = operation(engine, rows, num_perm, args.seed, args.prehashed)
                     result = measure(run, extract, args.repetitions, args.min_sample_seconds, args.warmup_seconds)
                     result.update(input_metadata)
                 else:
@@ -187,7 +274,7 @@ def main():
                 print(f"{engine:14s} rows={result['rows']:5d} tokens={size} perm={num_perm}: "
                       f"{result['median_seconds']:.6f}s", flush=True)
             if len(checksums) != 1:
-                raise RuntimeError("Engines did not receive identical input bytes")
+                raise RuntimeError("Engines did not receive identical inputs")
             args.output_json.write_text(json.dumps(report, indent=2) + "\n")
 
 

--- a/benchmarks/sketch_benchmark.py
+++ b/benchmarks/sketch_benchmark.py
@@ -26,6 +26,7 @@ THREAD_ENV = (
 )
 for variable in THREAD_ENV:
     os.environ[variable] = "1"
+os.environ["RENSA_PIPELINE_QUEUE_CAP"] = "0"
 
 from datasketch import MinHash
 from FastSketchLSH import FastSimilaritySketch
@@ -144,6 +145,7 @@ def main():
             "versions": {name: importlib.metadata.version(name)
                          for name in ("rensa", "datasketch", "FastSketchLSH", "numpy")},
             "cminhash_algorithm_version": getattr(CMinHash, "ALGORITHM_VERSION", None),
+            "rminhash_algorithm_version": getattr(RMinHash, "ALGORITHM_VERSION", 1),
             "flags": {key: value for key, value in sorted(os.environ.items())
                       if key in THREAD_ENV or key.startswith("RENSA_")},
         },

--- a/benchmarks/sketch_benchmark.py
+++ b/benchmarks/sketch_benchmark.py
@@ -208,6 +208,8 @@ def main():
         parser.error("repeat-cardinality must be positive")
     if "fastsketch" in args.engines and any(k & (k - 1) or k > 4096 for k in args.num_perm):
         parser.error("FastSketch requires power-of-two num-perm no greater than 4096")
+    if "fastsketch" in args.engines and not args.prehashed and 0 in args.sizes and not args.token_cache:
+        parser.error("FastSketch's byte API rejects empty rows; use prehashed mode for size zero")
     if not 0 <= args.seed <= 2**32 - 1:
         parser.error("seed must fit the shared unsigned 32-bit seed range")
     if not all(0 <= value < float("inf") for value in (args.min_sample_seconds, args.warmup_seconds)):

--- a/src/cminhash.rs
+++ b/src/cminhash.rs
@@ -1,19 +1,15 @@
-//! Implementation of C-MinHash, an optimized `MinHash` variant.
-//! This algorithm provides an efficient way to estimate Jaccard similarity
-//! between sets, using a technique that rigorously reduces K permutations to two.
+//! Practical C-MinHash using two seeded 64-bit permutations.
 //!
-//! - C-MinHash: Rigorously Reducing K Permutations to Two.
-//!   Ping Li, Arnd Christian König.
-//!   [arXiv:2109.03337](https://arxiv.org/abs/2109.03337)
+//! Xiaoyun Li and Ping Li, *C-MinHash: Improving Minwise Hashing with
+//! Circulant Permutation*, ICML 2022:
+//! <https://proceedings.mlr.press/v162/li22m.html>.
 //!
-//! The implementation focuses on high single-threaded performance through
-//! optimized memory access patterns and batch processing. It uses two main
-//! hash transformations:
-//!   - An initial permutation σ applied to item hashes.
-//!   - A second set of parameters π used to generate the `num_perm` signature values.
-//!
-//! The `update` method processes items in batches to improve cache utilization,
-//! and the Jaccard calculation is optimized using chunked operations.
+//! For each token hash `x`, the signature takes the minimum of
+//! `pi(sigma(x) - (k + 1))`, with subtraction modulo 2^64. The subtraction
+//! rotates the input coordinates of `pi`, as in the paper's right circulant
+//! shifts. Independently seeded `SplitMix64` finalizers approximate the paper's
+//! uniformly random permutations; its exact variance theorem does not apply
+//! to this restricted pseudorandom family.
 
 use pyo3::prelude::*;
 use rand_core::{RngCore, SeedableRng};
@@ -25,62 +21,57 @@ mod core;
 mod py;
 
 const HASH_BATCH_SIZE: usize = 32;
+const STATE_VERSION: u32 = 0x434d_4802;
+const PY_STATE_PREFIX: &[u8] = b"Rensa:CMinHash:2\0";
 type ReduceResult = (Py<PyAny>, (usize, u64), Py<PyAny>);
 
-/// `CMinHash` implements an optimized version of `C-MinHash` with better memory access patterns
-/// and aggressive optimizations for maximum single-threaded performance.
+/// A C-MinHash sketch with seeded pseudorandom circulant permutations.
 #[derive(Serialize, Clone)]
 #[pyclass(module = "rensa", skip_from_py_object)]
 pub struct CMinHash {
+  version: u32,
   num_perm: usize,
   seed: u64,
   hash_values: Vec<u64>,
-  // Permutation σ parameters (a, b)
-  sigma_a: u64,
-  sigma_b: u64,
-  // Permutation π parameters (c, d)
-  pi_c: u64,
-  pi_d: u64,
-  // Precomputed pi_c * k + pi_d for k in 0..num_perm
-  #[serde(skip, default)]
-  pi_precomputed: Vec<u64>,
+  #[serde(skip)]
+  sigma_key: u64,
+  #[serde(skip)]
+  pi_key: u64,
 }
 
 #[derive(Deserialize)]
 struct CMinHashState {
+  #[serde(deserialize_with = "deserialize_version")]
+  version: u32,
   num_perm: usize,
   seed: u64,
   hash_values: Vec<u64>,
-  sigma_a: u64,
-  sigma_b: u64,
-  pi_c: u64,
-  pi_d: u64,
 }
 
-#[derive(Clone)]
+fn deserialize_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  let version = u32::deserialize(deserializer)?;
+  if version != STATE_VERSION {
+    return Err(serde::de::Error::custom(
+      "unsupported CMinHash state version; rebuild the sketch from its tokens",
+    ));
+  }
+  Ok(version)
+}
+
 pub(in crate::cminhash) struct CMinHashParams {
-  pub(in crate::cminhash) sigma_a: u64,
-  pub(in crate::cminhash) sigma_b: u64,
-  pub(in crate::cminhash) pi_c: u64,
-  pub(in crate::cminhash) pi_d: u64,
-  pub(in crate::cminhash) pi_precomputed: Vec<u64>,
+  pub(in crate::cminhash) sigma_key: u64,
+  pub(in crate::cminhash) pi_key: u64,
 }
 
 impl CMinHashParams {
-  pub(in crate::cminhash) fn new(num_perm: usize, seed: u64) -> Self {
+  pub(in crate::cminhash) fn new(seed: u64) -> Self {
     let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
-    let sigma_a = rng.next_u64() | 1;
-    let sigma_b = rng.next_u64();
-    let pi_c = rng.next_u64() | 1;
-    let pi_d = rng.next_u64();
-    let pi_precomputed = CMinHash::build_pi_precomputed(num_perm, pi_c, pi_d);
-
     Self {
-      sigma_a,
-      sigma_b,
-      pi_c,
-      pi_d,
-      pi_precomputed,
+      sigma_key: rng.next_u64(),
+      pi_key: rng.next_u64(),
     }
   }
 }
@@ -91,15 +82,74 @@ impl<'de> Deserialize<'de> for CMinHash {
     D: Deserializer<'de>,
   {
     let state = CMinHashState::deserialize(deserializer)?;
+    if state.num_perm == 0 || state.hash_values.len() != state.num_perm {
+      return Err(serde::de::Error::custom(
+        "invalid CMinHash state: num_perm must equal the nonempty hash_values length",
+      ));
+    }
+    let params = CMinHashParams::new(state.seed);
     Ok(Self {
+      version: state.version,
       num_perm: state.num_perm,
       seed: state.seed,
       hash_values: state.hash_values,
-      sigma_a: state.sigma_a,
-      sigma_b: state.sigma_b,
-      pi_c: state.pi_c,
-      pi_d: state.pi_d,
-      pi_precomputed: Vec::new(),
+      sigma_key: params.sigma_key,
+      pi_key: params.pi_key,
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::cminhash::{CMinHash, STATE_VERSION};
+  use serde::Serialize;
+
+  #[test]
+  fn serialized_sketch_restores_permutations_for_further_updates(
+  ) -> pyo3::PyResult<()> {
+    let mut original = CMinHash::new(129, 42)?;
+    original.update_iter(["first", "second"]);
+    let bytes = postcard::to_allocvec(&original).unwrap();
+    let mut restored: CMinHash = postcard::from_bytes(&bytes).unwrap();
+    assert_eq!(restored.hash_values, original.hash_values);
+    original.update_iter(["third", "fourth"]);
+    restored.update_iter(["third", "fourth"]);
+    assert_eq!(restored.hash_values, original.hash_values);
+    Ok(())
+  }
+
+  #[test]
+  fn serialization_rejects_legacy_or_invalid_states() {
+    #[derive(Serialize)]
+    struct LegacyState {
+      num_perm: usize,
+      seed: u64,
+      hash_values: Vec<u64>,
+      sigma_a: u64,
+      sigma_b: u64,
+      pi_c: u64,
+      pi_d: u64,
+    }
+    let legacy = LegacyState {
+      num_perm: 128,
+      seed: 42,
+      hash_values: vec![u64::MAX; 128],
+      sigma_a: 1,
+      sigma_b: 2,
+      pi_c: 3,
+      pi_d: 4,
+    };
+    let bytes = postcard::to_allocvec(&legacy).unwrap();
+    assert!(postcard::from_bytes::<CMinHash>(&bytes).is_err());
+
+    for (version, num_perm, values) in [
+      (STATE_VERSION + 1, 1_usize, vec![0_u64]),
+      (STATE_VERSION, 0, vec![]),
+      (STATE_VERSION, 2, vec![0]),
+    ] {
+      let bytes =
+        postcard::to_allocvec(&(version, num_perm, 42_u64, values)).unwrap();
+      assert!(postcard::from_bytes::<CMinHash>(&bytes).is_err());
+    }
   }
 }

--- a/src/cminhash/batch.rs
+++ b/src/cminhash/batch.rs
@@ -1,4 +1,6 @@
-use crate::cminhash::{CMinHash, CMinHashParams, HASH_BATCH_SIZE};
+use crate::cminhash::{
+  CMinHash, CMinHashParams, HASH_BATCH_SIZE, STATE_VERSION,
+};
 use crate::py_input::{
   extend_prehashed_token_values_from_document,
   extend_token_hashes_from_document,
@@ -22,7 +24,7 @@ impl CMinHash {
     let capacity = Self::token_sets_capacity(token_sets);
     let mut outputs = Vec::with_capacity(capacity);
     let mut token_hashes = Vec::with_capacity(HASH_BATCH_SIZE);
-    let params = CMinHashParams::new(num_perm, seed);
+    let params = CMinHashParams::new(seed);
     let mut hash_values = vec![u64::MAX; num_perm];
 
     Self::for_each_document(token_sets, |document| {
@@ -33,10 +35,8 @@ impl CMinHash {
       Self::apply_token_hashes_to_values(
         &mut hash_values,
         &token_hashes,
-        params.sigma_a,
-        params.sigma_b,
-        params.pi_c,
-        &params.pi_precomputed,
+        params.sigma_key,
+        params.pi_key,
       );
 
       outputs.push(map(&hash_values));
@@ -61,7 +61,7 @@ impl CMinHash {
     let capacity = Self::token_sets_capacity(token_sets);
     let mut outputs = Vec::with_capacity(capacity);
     let mut token_hashes = Vec::with_capacity(HASH_BATCH_SIZE);
-    let params = CMinHashParams::new(num_perm, seed);
+    let params = CMinHashParams::new(seed);
 
     Self::for_each_document(token_sets, |document| {
       token_hashes.clear();
@@ -71,10 +71,8 @@ impl CMinHash {
       Self::apply_token_hashes_to_values(
         &mut hash_values,
         &token_hashes,
-        params.sigma_a,
-        params.sigma_b,
-        params.pi_c,
-        &params.pi_precomputed,
+        params.sigma_key,
+        params.pi_key,
       );
 
       outputs.push(map(hash_values, &params));
@@ -135,14 +133,12 @@ impl CMinHash {
       seed,
       extend_token_hashes_from_document,
       |hash_values, params| Self {
+        version: STATE_VERSION,
         num_perm,
         seed,
         hash_values,
-        sigma_a: params.sigma_a,
-        sigma_b: params.sigma_b,
-        pi_c: params.pi_c,
-        pi_d: params.pi_d,
-        pi_precomputed: Vec::new(),
+        sigma_key: params.sigma_key,
+        pi_key: params.pi_key,
       },
     )
   }

--- a/src/cminhash/core.rs
+++ b/src/cminhash/core.rs
@@ -1,4 +1,4 @@
-use crate::cminhash::{CMinHash, HASH_BATCH_SIZE};
+use crate::cminhash::{CMinHash, HASH_BATCH_SIZE, STATE_VERSION};
 use crate::utils::{calculate_hash_fast, ratio_usize};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -35,16 +35,6 @@ impl SigmaBatch {
 }
 
 impl CMinHash {
-  pub(in crate::cminhash) fn build_pi_precomputed(
-    num_perm: usize,
-    pi_c: u64,
-    pi_d: u64,
-  ) -> Vec<u64> {
-    (0..num_perm)
-      .map(|k| pi_c.wrapping_mul(k as u64).wrapping_add(pi_d))
-      .collect()
-  }
-
   #[inline]
   pub(crate) const fn num_perm(&self) -> usize {
     self.num_perm
@@ -78,15 +68,6 @@ impl CMinHash {
         self.num_perm
       )));
     }
-    if !self.pi_precomputed.is_empty()
-      && self.pi_precomputed.len() != self.num_perm
-    {
-      return Err(PyValueError::new_err(format!(
-        "invalid CMinHash state: pi_precomputed length {} does not match num_perm {} (or be compacted to 0)",
-        self.pi_precomputed.len(),
-        self.num_perm
-      )));
-    }
     Ok(())
   }
 
@@ -111,16 +92,18 @@ impl CMinHash {
     Ok(())
   }
 
+  // SplitMix64's bijective finalizer, by Sebastiano Vigna:
+  // https://prng.di.unimi.it/splitmix64.c
   #[inline]
-  const fn sigma_transform(&self, hash: u64) -> u64 {
-    self.sigma_a.wrapping_mul(hash).wrapping_add(self.sigma_b)
+  const fn mix64(mut value: u64) -> u64 {
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
   }
 
-  fn ensure_pi_precomputed(&mut self) {
-    if self.pi_precomputed.len() != self.num_perm {
-      self.pi_precomputed =
-        Self::build_pi_precomputed(self.num_perm, self.pi_c, self.pi_d);
-    }
+  #[inline]
+  const fn sigma_transform(&self, hash: u64) -> u64 {
+    Self::mix64(hash.wrapping_add(self.sigma_key))
   }
 
   #[inline]
@@ -172,41 +155,30 @@ impl CMinHash {
 
   fn apply_sigma_batch_to_values(
     hash_values: &mut [u64],
-    pi_precomputed: &[u64],
-    pi_c: u64,
+    pi_key: u64,
     sigma_batch: &[u64],
   ) {
-    debug_assert_eq!(hash_values.len(), pi_precomputed.len());
-
+    let remainder_start = hash_values.len() / 16 * 16;
     let mut hash_chunks = hash_values.chunks_exact_mut(16);
-    let mut pi_chunks = pi_precomputed.chunks_exact(16);
-
-    for (hash_chunk, pi_chunk) in hash_chunks.by_ref().zip(pi_chunks.by_ref()) {
+    for (block, hash_chunk) in hash_chunks.by_ref().enumerate() {
       let mut current = [0u64; 16];
       current.copy_from_slice(hash_chunk);
-
-      for &sigma_h in sigma_batch {
-        let base = pi_c.wrapping_mul(sigma_h);
-
-        for i in 0..16 {
-          let pi_value = base.wrapping_add(pi_chunk[i]);
-          current[i] = current[i].min(pi_value);
+      let shift = (block as u64).wrapping_mul(16).wrapping_add(1);
+      for &sigma in sigma_batch {
+        let base = sigma.wrapping_add(pi_key).wrapping_sub(shift);
+        for (lane, value) in current.iter_mut().enumerate() {
+          *value = (*value).min(Self::mix64(base.wrapping_sub(lane as u64)));
         }
       }
-
       hash_chunk.copy_from_slice(&current);
     }
 
-    let hash_remainder = hash_chunks.into_remainder();
-    let pi_remainder = pi_chunks.remainder();
-    debug_assert_eq!(hash_remainder.len(), pi_remainder.len());
-
-    for &sigma_h in sigma_batch {
-      let base = pi_c.wrapping_mul(sigma_h);
-
-      for (hash_val, &pi_val) in hash_remainder.iter_mut().zip(pi_remainder) {
-        let pi_value = base.wrapping_add(pi_val);
-        *hash_val = (*hash_val).min(pi_value);
+    let remainder = hash_chunks.into_remainder();
+    let shift = (remainder_start as u64).wrapping_add(1);
+    for &sigma in sigma_batch {
+      let base = sigma.wrapping_add(pi_key).wrapping_sub(shift);
+      for (lane, value) in remainder.iter_mut().enumerate() {
+        *value = (*value).min(Self::mix64(base.wrapping_sub(lane as u64)));
       }
     }
   }
@@ -214,8 +186,7 @@ impl CMinHash {
   fn apply_sigma_batch(&mut self, sigma_batch: &[u64]) {
     Self::apply_sigma_batch_to_values(
       &mut self.hash_values,
-      &self.pi_precomputed,
-      self.pi_c,
+      self.pi_key,
       sigma_batch,
     );
   }
@@ -223,38 +194,16 @@ impl CMinHash {
   pub(in crate::cminhash) fn apply_token_hashes_to_values(
     hash_values: &mut [u64],
     token_hashes: &[u64],
-    sigma_a: u64,
-    sigma_b: u64,
-    pi_c: u64,
-    pi_precomputed: &[u64],
+    sigma_key: u64,
+    pi_key: u64,
   ) {
-    if token_hashes.len() >= 128 && hash_values.len() >= 128 {
-      let a = pi_c.wrapping_mul(sigma_a);
-      let b = pi_c.wrapping_mul(sigma_b);
-      let mut bases: Vec<u64> = token_hashes
-        .iter()
-        .map(|&hash| a.wrapping_mul(hash).wrapping_add(b))
-        .collect();
-      bases.sort_unstable();
-
-      for (value, &pi) in hash_values.iter_mut().zip(pi_precomputed) {
-        // Wrapping addition is smallest at the first base that wraps, or
-        // the smallest base when none wraps. Equal bases wrap exactly to zero.
-        let index = bases.partition_point(|&base| base < pi.wrapping_neg());
-        let base = bases.get(index).copied().unwrap_or(bases[0]);
-        *value = (*value).min(base.wrapping_add(pi));
-      }
-      return;
-    }
-
     let mut sigma_batch = SigmaBatch::default();
     for &token_hash in token_hashes {
-      let sigma_h = sigma_a.wrapping_mul(token_hash).wrapping_add(sigma_b);
-      if sigma_batch.push(sigma_h) {
+      let sigma = Self::mix64(token_hash.wrapping_add(sigma_key));
+      if sigma_batch.push(sigma) {
         Self::apply_sigma_batch_to_values(
           hash_values,
-          pi_precomputed,
-          pi_c,
+          pi_key,
           sigma_batch.as_slice(),
         );
         sigma_batch.clear();
@@ -263,8 +212,7 @@ impl CMinHash {
     if !sigma_batch.is_empty() {
       Self::apply_sigma_batch_to_values(
         hash_values,
-        pi_precomputed,
-        pi_c,
+        pi_key,
         sigma_batch.as_slice(),
       );
     }
@@ -272,14 +220,12 @@ impl CMinHash {
 
   pub(crate) fn compact_from_template(template: &Self) -> Self {
     Self {
+      version: STATE_VERSION,
       num_perm: template.num_perm,
       seed: template.seed,
       hash_values: vec![u64::MAX; template.num_perm],
-      sigma_a: template.sigma_a,
-      sigma_b: template.sigma_b,
-      pi_c: template.pi_c,
-      pi_d: template.pi_d,
-      pi_precomputed: Vec::new(),
+      sigma_key: template.sigma_key,
+      pi_key: template.pi_key,
     }
   }
 
@@ -292,10 +238,8 @@ impl CMinHash {
     Self::apply_token_hashes_to_values(
       &mut self.hash_values,
       token_hashes,
-      template.sigma_a,
-      template.sigma_b,
-      template.pi_c,
-      &template.pi_precomputed,
+      template.sigma_key,
+      template.pi_key,
     );
   }
 
@@ -304,7 +248,6 @@ impl CMinHash {
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
   {
-    self.ensure_pi_precomputed();
     let mut sigma_batch = SigmaBatch::default();
 
     for item in items {
@@ -324,14 +267,11 @@ impl CMinHash {
     &mut self,
     token_hashes: &[u64],
   ) {
-    self.ensure_pi_precomputed();
     Self::apply_token_hashes_to_values(
       &mut self.hash_values,
       token_hashes,
-      self.sigma_a,
-      self.sigma_b,
-      self.pi_c,
-      &self.pi_precomputed,
+      self.sigma_key,
+      self.pi_key,
     );
   }
 
@@ -356,17 +296,35 @@ mod tests {
   use rand_core::{RngCore, SeedableRng};
   use rand_xoshiro::Xoshiro256PlusPlus;
 
+  fn reference_permutation(value: u64, key: u64) -> u64 {
+    let mut value = value.wrapping_add(key);
+    value ^= value >> 30;
+    value = value.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value ^= value >> 27;
+    value = value.wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+  }
+
   #[test]
-  fn token_hash_updates_match_naive_wrapping_permutations() {
+  fn token_hash_updates_match_scalar_circulant_reference() {
     for seed in [0, 1, 42, u64::MAX] {
       let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
       for num_perm in [1, 16, 128, 129, 512] {
-        let params = CMinHashParams::new(num_perm, seed);
+        let params = CMinHashParams::new(seed);
         for token_len in [0, 1, 31, 32, 127, 128, 1024] {
           let mut hashes: Vec<u64> =
             (0..token_len).map(|_| rng.next_u64()).collect();
-          for (index, hash) in hashes.iter_mut().take(4).enumerate() {
-            *hash = if index % 2 == 0 { 0 } else { u64::MAX };
+          for (hash, boundary) in hashes.iter_mut().zip([
+            0,
+            1,
+            u64::MAX - 1,
+            u64::MAX,
+            1 << 63,
+            u64::from(u32::MAX),
+            1 << 32,
+            params.sigma_key.wrapping_neg(),
+          ]) {
+            *hash = boundary;
           }
           for populated in [false, true] {
             let initial: Vec<u64> = (0..num_perm)
@@ -374,15 +332,10 @@ mod tests {
               .collect();
             let mut expected = initial.clone();
             for &hash in &hashes {
-              let sigma = params
-                .sigma_a
-                .wrapping_mul(hash)
-                .wrapping_add(params.sigma_b);
+              let sigma = reference_permutation(hash, params.sigma_key);
               for (k, value) in expected.iter_mut().enumerate() {
-                let permuted = params
-                  .pi_c
-                  .wrapping_mul(sigma.wrapping_add(k as u64))
-                  .wrapping_add(params.pi_d);
+                let shifted = sigma.wrapping_sub(k as u64 + 1);
+                let permuted = reference_permutation(shifted, params.pi_key);
                 *value = (*value).min(permuted);
               }
             }
@@ -390,10 +343,8 @@ mod tests {
             CMinHash::apply_token_hashes_to_values(
               &mut actual,
               &hashes,
-              params.sigma_a,
-              params.sigma_b,
-              params.pi_c,
-              &params.pi_precomputed,
+              params.sigma_key,
+              params.pi_key,
             );
             assert_eq!(actual, expected);
 
@@ -402,10 +353,8 @@ mod tests {
               CMinHash::apply_token_hashes_to_values(
                 &mut incremental,
                 chunk,
-                params.sigma_a,
-                params.sigma_b,
-                params.pi_c,
-                &params.pi_precomputed,
+                params.sigma_key,
+                params.pi_key,
               );
             }
             assert_eq!(incremental, expected);
@@ -415,18 +364,6 @@ mod tests {
     }
   }
 
-  #[test]
-  fn sorted_successors_handle_exact_wrap_and_zero_offset() {
-    let hashes = [0, u64::MAX].repeat(64);
-    let pi: Vec<u64> = [0, 1, u64::MAX, 2].repeat(32);
-    let mut actual = vec![u64::MAX; pi.len()];
-    CMinHash::apply_token_hashes_to_values(&mut actual, &hashes, 1, 0, 1, &pi);
-    let expected: Vec<u64> = pi
-      .iter()
-      .map(|&offset| offset.min(u64::MAX.wrapping_add(offset)))
-      .collect();
-    assert_eq!(actual, expected);
-  }
   #[test]
   fn threshold_predicate_matches_full_jaccard_at_float_boundaries(
   ) -> pyo3::PyResult<()> {

--- a/src/cminhash/core.rs
+++ b/src/cminhash/core.rs
@@ -146,6 +146,25 @@ impl CMinHash {
     ratio_usize(equal_count, self.num_perm)
   }
 
+  #[inline]
+  pub(crate) fn jaccard_at_least_unchecked(
+    &self,
+    other: &Self,
+    threshold: f64,
+  ) -> bool {
+    let mut mismatches = 0;
+    for (left, right) in
+      self.hash_values.chunks(8).zip(other.hash_values.chunks(8))
+    {
+      mismatches += left.iter().zip(right).filter(|(a, b)| a != b).count();
+      // Even if all remaining lanes match, this pair cannot reach threshold.
+      if ratio_usize(self.num_perm - mismatches, self.num_perm) < threshold {
+        return false;
+      }
+    }
+    true
+  }
+
   fn apply_sigma_batch_to_values(
     hash_values: &mut [u64],
     pi_precomputed: &[u64],
@@ -204,6 +223,25 @@ impl CMinHash {
     pi_c: u64,
     pi_precomputed: &[u64],
   ) {
+    if token_hashes.len() >= 128 && hash_values.len() >= 128 {
+      let a = pi_c.wrapping_mul(sigma_a);
+      let b = pi_c.wrapping_mul(sigma_b);
+      let mut bases: Vec<u64> = token_hashes
+        .iter()
+        .map(|&hash| a.wrapping_mul(hash).wrapping_add(b))
+        .collect();
+      bases.sort_unstable();
+
+      for (value, &pi) in hash_values.iter_mut().zip(pi_precomputed) {
+        // Wrapping addition is smallest at the first base that wraps, or
+        // the smallest base when none wraps. Equal bases wrap exactly to zero.
+        let index = bases.partition_point(|&base| base < pi.wrapping_neg());
+        let base = bases.get(index).copied().unwrap_or(bases[0]);
+        *value = (*value).min(base.wrapping_add(pi));
+      }
+      return;
+    }
+
     let mut sigma_batch = SigmaBatch::default();
     for &token_hash in token_hashes {
       let sigma_h = sigma_a.wrapping_mul(token_hash).wrapping_add(sigma_b);
@@ -304,5 +342,127 @@ impl CMinHash {
   /// Updates the `CMinHash` with a new set of items from a vector of strings.
   pub fn update_vec(&mut self, items: Vec<String>) {
     self.update_iter(items);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::cminhash::{CMinHash, CMinHashParams};
+  use rand_core::{RngCore, SeedableRng};
+  use rand_xoshiro::Xoshiro256PlusPlus;
+
+  #[test]
+  fn token_hash_updates_match_naive_wrapping_permutations() {
+    for seed in [0, 1, 42, u64::MAX] {
+      let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
+      for num_perm in [1, 16, 128, 129, 512] {
+        let params = CMinHashParams::new(num_perm, seed);
+        for token_len in [0, 1, 31, 32, 127, 128, 1024] {
+          let mut hashes: Vec<u64> =
+            (0..token_len).map(|_| rng.next_u64()).collect();
+          for (index, hash) in hashes.iter_mut().take(4).enumerate() {
+            *hash = if index % 2 == 0 { 0 } else { u64::MAX };
+          }
+          for populated in [false, true] {
+            let initial: Vec<u64> = (0..num_perm)
+              .map(|_| if populated { rng.next_u64() } else { u64::MAX })
+              .collect();
+            let mut expected = initial.clone();
+            for &hash in &hashes {
+              let sigma = params
+                .sigma_a
+                .wrapping_mul(hash)
+                .wrapping_add(params.sigma_b);
+              for (k, value) in expected.iter_mut().enumerate() {
+                let permuted = params
+                  .pi_c
+                  .wrapping_mul(sigma.wrapping_add(k as u64))
+                  .wrapping_add(params.pi_d);
+                *value = (*value).min(permuted);
+              }
+            }
+            let mut actual = initial.clone();
+            CMinHash::apply_token_hashes_to_values(
+              &mut actual,
+              &hashes,
+              params.sigma_a,
+              params.sigma_b,
+              params.pi_c,
+              &params.pi_precomputed,
+            );
+            assert_eq!(actual, expected);
+
+            let mut incremental = initial;
+            for chunk in hashes.chunks(129) {
+              CMinHash::apply_token_hashes_to_values(
+                &mut incremental,
+                chunk,
+                params.sigma_a,
+                params.sigma_b,
+                params.pi_c,
+                &params.pi_precomputed,
+              );
+            }
+            assert_eq!(incremental, expected);
+          }
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn sorted_successors_handle_exact_wrap_and_zero_offset() {
+    let hashes = [0, u64::MAX].repeat(64);
+    let pi: Vec<u64> = [0, 1, u64::MAX, 2].repeat(32);
+    let mut actual = vec![u64::MAX; pi.len()];
+    CMinHash::apply_token_hashes_to_values(&mut actual, &hashes, 1, 0, 1, &pi);
+    let expected: Vec<u64> = pi
+      .iter()
+      .map(|&offset| offset.min(u64::MAX.wrapping_add(offset)))
+      .collect();
+    assert_eq!(actual, expected);
+  }
+  #[test]
+  fn threshold_predicate_matches_full_jaccard_at_float_boundaries(
+  ) -> pyo3::PyResult<()> {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(78);
+    for num_perm in [1, 7, 8, 17, 63, 129] {
+      let mut left = CMinHash::new(num_perm, 42)?;
+      let mut right = CMinHash::new(num_perm, 42)?;
+      for matching in 0..=num_perm {
+        for (index, (a, b)) in left
+          .hash_values
+          .iter_mut()
+          .zip(&mut right.hash_values)
+          .enumerate()
+        {
+          *a = rng.next_u64();
+          *b = if index < matching { *a } else { !*a };
+        }
+        // Shuffle both signatures together to distribute matches throughout
+        // the chunks, while retaining exactly the chosen number of matches.
+        for index in 1..num_perm {
+          let other =
+            usize::try_from(rng.next_u64() % (index as u64 + 1)).unwrap();
+          left.hash_values.swap(index, other);
+          right.hash_values.swap(index, other);
+        }
+        let similarity = left.jaccard_unchecked(&right);
+        let below = if similarity == 0.0 {
+          0.0
+        } else {
+          f64::from_bits(similarity.to_bits() - 1)
+        };
+        let above = f64::from_bits(similarity.to_bits() + 1);
+        for threshold in [0.0, 1.0, 0.8, similarity, below, above] {
+          assert_eq!(
+            left.jaccard_at_least_unchecked(&right, threshold),
+            similarity >= threshold,
+            "num_perm={num_perm}, matching={matching}, threshold={threshold}"
+          );
+        }
+      }
+    }
+    Ok(())
   }
 }

--- a/src/cminhash/core.rs
+++ b/src/cminhash/core.rs
@@ -1,4 +1,4 @@
-use crate::cminhash::{CMinHash, HASH_BATCH_SIZE, STATE_VERSION};
+use crate::cminhash::{CMinHash, HASH_BATCH_SIZE};
 use crate::utils::{calculate_hash_fast, ratio_usize};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -218,29 +218,9 @@ impl CMinHash {
     }
   }
 
-  pub(crate) fn compact_from_template(template: &Self) -> Self {
-    Self {
-      version: STATE_VERSION,
-      num_perm: template.num_perm,
-      seed: template.seed,
-      hash_values: vec![u64::MAX; template.num_perm],
-      sigma_key: template.sigma_key,
-      pi_key: template.pi_key,
-    }
-  }
-
-  pub(crate) fn reset_from_token_hashes_with_template(
-    &mut self,
-    token_hashes: &[u64],
-    template: &Self,
-  ) {
+  pub(crate) fn reset_from_token_hashes(&mut self, token_hashes: &[u64]) {
     self.hash_values.fill(u64::MAX);
-    Self::apply_token_hashes_to_values(
-      &mut self.hash_values,
-      token_hashes,
-      template.sigma_key,
-      template.pi_key,
-    );
+    self.update_hashed_tokens(token_hashes);
   }
 
   fn update_internal<I, S>(&mut self, items: I)

--- a/src/cminhash/core.rs
+++ b/src/cminhash/core.rs
@@ -51,6 +51,11 @@ impl CMinHash {
   }
 
   #[inline]
+  pub(crate) fn signature_values(&self) -> &[u64] {
+    &self.hash_values
+  }
+
+  #[inline]
   pub(crate) const fn seed(&self) -> u64 {
     self.seed
   }

--- a/src/cminhash/core.rs
+++ b/src/cminhash/core.rs
@@ -97,6 +97,12 @@ impl CMinHash {
         self.num_perm, other.num_perm
       )));
     }
+    if self.seed != other.seed {
+      return Err(PyValueError::new_err(format!(
+        "seed mismatch: left is {}, right is {}",
+        self.seed, other.seed
+      )));
+    }
     Ok(())
   }
 

--- a/src/cminhash/py.rs
+++ b/src/cminhash/py.rs
@@ -1,5 +1,6 @@
 use crate::cminhash::{
-  CMinHash, CMinHashParams, ReduceResult, HASH_BATCH_SIZE,
+  CMinHash, CMinHashParams, ReduceResult, HASH_BATCH_SIZE, PY_STATE_PREFIX,
+  STATE_VERSION,
 };
 use crate::py_input::extend_token_hashes_from_document;
 use pyo3::exceptions::PyValueError;
@@ -27,6 +28,10 @@ fn update_with_token_hash_buffer(
 
 #[pymethods]
 impl CMinHash {
+  /// Signature algorithm version; signatures from different versions are incompatible.
+  #[classattr]
+  const ALGORITHM_VERSION: u32 = 2;
+
   /// Creates a new `CMinHash` instance.
   ///
   /// # Arguments
@@ -41,17 +46,15 @@ impl CMinHash {
   pub fn new(num_perm: usize, seed: u64) -> PyResult<Self> {
     Self::validate_num_perm(num_perm)?;
 
-    let params = CMinHashParams::new(num_perm, seed);
+    let params = CMinHashParams::new(seed);
 
     Ok(Self {
+      version: STATE_VERSION,
       num_perm,
       seed,
       hash_values: vec![u64::MAX; num_perm],
-      sigma_a: params.sigma_a,
-      sigma_b: params.sigma_b,
-      pi_c: params.pi_c,
-      pi_d: params.pi_d,
-      pi_precomputed: params.pi_precomputed,
+      sigma_key: params.sigma_key,
+      pi_key: params.pi_key,
     })
   }
 
@@ -178,12 +181,16 @@ impl CMinHash {
   }
 
   fn __setstate__(&mut self, state: &Bound<'_, PyBytes>) -> PyResult<()> {
-    let decoded: Self =
-      postcard::from_bytes(state.as_bytes()).map_err(|err| {
-        PyValueError::new_err(format!(
-          "failed to deserialize CMinHash state: {err}"
-        ))
-      })?;
+    let payload = state.as_bytes().strip_prefix(PY_STATE_PREFIX).ok_or_else(|| {
+      PyValueError::new_err(
+        "unsupported CMinHash state version; rebuild the sketch from its tokens",
+      )
+    })?;
+    let decoded: Self = postcard::from_bytes(payload).map_err(|err| {
+      PyValueError::new_err(format!(
+        "failed to deserialize CMinHash state: {err}"
+      ))
+    })?;
     decoded.validate_state()?;
     *self = decoded;
     Ok(())
@@ -193,11 +200,12 @@ impl CMinHash {
     &self,
     py: Python<'py>,
   ) -> PyResult<Bound<'py, PyBytes>> {
-    let encoded = postcard::to_allocvec(self).map_err(|err| {
-      PyValueError::new_err(format!(
-        "failed to serialize CMinHash state: {err}"
-      ))
-    })?;
+    let encoded =
+      postcard::to_extend(self, PY_STATE_PREFIX.to_vec()).map_err(|err| {
+        PyValueError::new_err(format!(
+          "failed to serialize CMinHash state: {err}"
+        ))
+      })?;
     Ok(PyBytes::new(py, &encoded))
   }
 

--- a/src/cminhash/py.rs
+++ b/src/cminhash/py.rs
@@ -191,7 +191,6 @@ impl CMinHash {
         "failed to deserialize CMinHash state: {err}"
       ))
     })?;
-    decoded.validate_state()?;
     *self = decoded;
     Ok(())
   }

--- a/src/inline_dedup.rs
+++ b/src/inline_dedup.rs
@@ -29,6 +29,8 @@ pub struct RMinHashDeduplicator {
 pub struct CMinHashDeduplicator {
   threshold: f64,
   existing_signatures: FxHashMap<String, CMinHash>,
+  signature_bands: Vec<FxHashMap<u64, cminhash::SignatureBucket>>,
+  band_count: usize,
   num_perm: Option<usize>,
   configured_num_perm: Option<usize>,
   seed: u64,

--- a/src/inline_dedup.rs
+++ b/src/inline_dedup.rs
@@ -30,5 +30,6 @@ pub struct CMinHashDeduplicator {
   threshold: f64,
   existing_signatures: FxHashMap<String, CMinHash>,
   num_perm: Option<usize>,
+  configured_num_perm: Option<usize>,
   seed: u64,
 }

--- a/src/inline_dedup/cminhash.rs
+++ b/src/inline_dedup/cminhash.rs
@@ -233,7 +233,7 @@ impl CMinHashDeduplicator {
     }
 
     for existing_minhash in self.existing_signatures.values() {
-      if minhash.jaccard_unchecked(existing_minhash) >= self.threshold {
+      if minhash.jaccard_at_least_unchecked(existing_minhash, self.threshold) {
         return Ok(true);
       }
     }
@@ -269,7 +269,7 @@ impl CMinHashDeduplicator {
     let mut duplicates = Vec::new();
 
     for (key, existing_minhash) in &self.existing_signatures {
-      if minhash.jaccard_unchecked(existing_minhash) >= self.threshold {
+      if minhash.jaccard_at_least_unchecked(existing_minhash, self.threshold) {
         duplicates.push(key.clone());
       }
     }

--- a/src/inline_dedup/cminhash.rs
+++ b/src/inline_dedup/cminhash.rs
@@ -183,6 +183,7 @@ impl CMinHashDeduplicator {
       threshold,
       existing_signatures: FxHashMap::default(),
       num_perm,
+      configured_num_perm: num_perm,
       seed,
     })
   }
@@ -191,7 +192,6 @@ impl CMinHashDeduplicator {
   ///
   /// Returns an error when the supplied `CMinHash` has an incompatible configuration.
   pub fn add(&mut self, key: String, minhash: &CMinHash) -> PyResult<bool> {
-    self.validate_input_minhash(minhash)?;
     if self.is_duplicate(&key, minhash)? {
       return Ok(false);
     }
@@ -299,7 +299,7 @@ impl CMinHashDeduplicator {
   pub fn remove(&mut self, key: &str) -> bool {
     let removed = self.existing_signatures.remove(key).is_some();
     if self.existing_signatures.is_empty() {
-      self.num_perm = None;
+      self.num_perm = self.configured_num_perm;
     }
     removed
   }
@@ -316,6 +316,6 @@ impl CMinHashDeduplicator {
 
   pub fn clear(&mut self) {
     self.existing_signatures.clear();
-    self.num_perm = None;
+    self.num_perm = self.configured_num_perm;
   }
 }

--- a/src/inline_dedup/cminhash.rs
+++ b/src/inline_dedup/cminhash.rs
@@ -2,10 +2,16 @@ use crate::cminhash::CMinHash;
 use crate::inline_dedup::common::{validate_threshold, PAIR_ENTRY_ERROR};
 use crate::inline_dedup::CMinHashDeduplicator;
 use crate::py_input::extend_token_hashes_from_document;
+use crate::utils::ratio_usize;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyIterator, PyTuple};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+// Below this size, a linear scan is cheaper than constructing the band index.
+const MIN_INDEX_ENTRIES: usize = 128;
 
 const TOKEN_SET_TEMPLATE_ERROR: &str =
   "internal error: token-set template initialization failed";
@@ -137,7 +143,126 @@ where
   Ok(outcomes)
 }
 
+// Most bands have one entry, so allocate a vector only when bands collide.
+pub(super) enum SignatureBucket {
+  One(Arc<str>),
+  Many(Vec<Arc<str>>),
+}
+
+impl SignatureBucket {
+  fn push(&mut self, key: Arc<str>) {
+    match self {
+      Self::One(existing) => {
+        *self = Self::Many(vec![Arc::clone(existing), key]);
+      }
+      Self::Many(keys) => keys.push(key),
+    }
+  }
+
+  fn as_slice(&self) -> &[Arc<str>] {
+    match self {
+      Self::One(key) => std::slice::from_ref(key),
+      Self::Many(keys) => keys,
+    }
+  }
+
+  // Return whether the bucket can be removed from the index.
+  fn remove(&mut self, key: &str) -> bool {
+    match self {
+      Self::One(existing) => existing.as_ref() == key,
+      Self::Many(keys) => {
+        keys.retain(|existing| existing.as_ref() != key);
+        match keys.as_slice() {
+          [] => true,
+          [remaining] => {
+            *self = Self::One(Arc::clone(remaining));
+            false
+          }
+          _ => false,
+        }
+      }
+    }
+  }
+}
+
+fn insert_signature_bands(
+  index: &mut [FxHashMap<u64, SignatureBucket>],
+  key: &str,
+  signature: &CMinHash,
+) {
+  let key: Arc<str> = key.into();
+  let hashes = signature_band_hashes(signature.signature_values(), index.len());
+  for (band, (_, hash)) in index.iter_mut().zip(hashes) {
+    band
+      .entry(hash)
+      .and_modify(|bucket| bucket.push(Arc::clone(&key)))
+      .or_insert_with(|| SignatureBucket::One(Arc::clone(&key)));
+  }
+}
+
+// Find the first accepted integer match count with the exact comparison used
+// by verification. Multiplying threshold by num_perm can round differently.
+fn exact_band_count(num_perm: usize, threshold: f64) -> usize {
+  let mut low = 0;
+  let mut high = num_perm;
+  while low < high {
+    let middle = low + (high - low) / 2;
+    if ratio_usize(middle, num_perm) >= threshold {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  if low <= 1 {
+    // Zero matches accepts everything; one match offers only single-lane bands.
+    return 0;
+  }
+  num_perm - low + 1
+}
+
+fn signature_band_hashes(
+  values: &[u64],
+  band_count: usize,
+) -> impl Iterator<Item = (usize, u64)> + '_ {
+  let width = values.len() / band_count;
+  let extra = values.len() % band_count;
+  let mut start = 0;
+  (0..band_count).map(move |band| {
+    let end = start + width + usize::from(band < extra);
+    let mut hasher = FxHasher::default();
+    values[start..end].hash(&mut hasher);
+    start = end;
+    (band, hasher.finish())
+  })
+}
+
 impl CMinHashDeduplicator {
+  fn has_indexed_duplicate(&self, minhash: &CMinHash) -> bool {
+    // With d allowed mismatches, d+1 disjoint bands guarantee at least one
+    // entirely matching band. Hash collisions only add candidates to verify.
+    let mut seen = FxHashSet::default();
+    let hashes =
+      signature_band_hashes(minhash.signature_values(), self.band_count);
+    for (band, (_, hash)) in self.signature_bands.iter().zip(hashes) {
+      let Some(keys) = band.get(&hash) else {
+        continue;
+      };
+      for candidate in keys.as_slice() {
+        if !seen.insert(candidate.as_ref()) {
+          continue;
+        }
+        let Some(existing) = self.existing_signatures.get(candidate.as_ref())
+        else {
+          continue;
+        };
+        if minhash.jaccard_at_least_unchecked(existing, self.threshold) {
+          return true;
+        }
+      }
+    }
+    false
+  }
+
   #[inline]
   fn validate_input_minhash(&self, minhash: &CMinHash) -> PyResult<()> {
     if minhash.seed() != self.seed {
@@ -182,6 +307,8 @@ impl CMinHashDeduplicator {
     Ok(Self {
       threshold,
       existing_signatures: FxHashMap::default(),
+      signature_bands: Vec::new(),
+      band_count: 0,
       num_perm,
       configured_num_perm: num_perm,
       seed,
@@ -199,7 +326,23 @@ impl CMinHashDeduplicator {
     if self.num_perm.is_none() {
       self.num_perm = Some(minhash.num_perm());
     }
+    if self.existing_signatures.is_empty() {
+      self.band_count = exact_band_count(minhash.num_perm(), self.threshold);
+    }
+    if !self.signature_bands.is_empty() {
+      insert_signature_bands(&mut self.signature_bands, &key, minhash);
+    }
     self.existing_signatures.insert(key, minhash.clone());
+    if self.band_count > 0
+      && self.signature_bands.is_empty()
+      && self.existing_signatures.len() >= MIN_INDEX_ENTRIES
+    {
+      self.signature_bands =
+        (0..self.band_count).map(|_| FxHashMap::default()).collect();
+      for (key, signature) in &self.existing_signatures {
+        insert_signature_bands(&mut self.signature_bands, key, signature);
+      }
+    }
     Ok(true)
   }
 
@@ -230,6 +373,10 @@ impl CMinHashDeduplicator {
     self.validate_input_minhash(minhash)?;
     if self.existing_signatures.contains_key(key) {
       return Ok(true);
+    }
+
+    if !self.signature_bands.is_empty() {
+      return Ok(self.has_indexed_duplicate(minhash));
     }
 
     for existing_minhash in self.existing_signatures.values() {
@@ -297,11 +444,26 @@ impl CMinHashDeduplicator {
   }
 
   pub fn remove(&mut self, key: &str) -> bool {
-    let removed = self.existing_signatures.remove(key).is_some();
+    let Some(removed) = self.existing_signatures.remove(key) else {
+      return false;
+    };
+    if !self.signature_bands.is_empty() {
+      let hashes =
+        signature_band_hashes(removed.signature_values(), self.band_count);
+      for (band, (_, hash)) in self.signature_bands.iter_mut().zip(hashes) {
+        if let Some(keys) = band.get_mut(&hash) {
+          if keys.remove(key) {
+            band.remove(&hash);
+          }
+        }
+      }
+    }
     if self.existing_signatures.is_empty() {
       self.num_perm = self.configured_num_perm;
+      self.band_count = 0;
+      self.signature_bands.clear();
     }
-    removed
+    true
   }
 
   #[must_use]
@@ -316,6 +478,83 @@ impl CMinHashDeduplicator {
 
   pub fn clear(&mut self) {
     self.existing_signatures.clear();
+    self.signature_bands.clear();
+    self.band_count = 0;
     self.num_perm = self.configured_num_perm;
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::inline_dedup::cminhash::{
+    exact_band_count, signature_band_hashes,
+  };
+  use crate::utils::ratio_usize;
+
+  #[test]
+  fn signature_bucket_handles_collisions_and_removal() {
+    use crate::inline_dedup::cminhash::SignatureBucket;
+    use std::sync::Arc;
+
+    let mut bucket = SignatureBucket::One(Arc::from("first"));
+    assert!(!bucket.remove("missing"));
+    bucket.push(Arc::from("second"));
+    bucket.push(Arc::from("third"));
+    assert_eq!(bucket.as_slice().len(), 3);
+    assert!(!bucket.remove("second"));
+    assert_eq!(bucket.as_slice().len(), 2);
+    assert!(!bucket.remove("first"));
+    assert!(matches!(bucket, SignatureBucket::One(_)));
+    assert_eq!(bucket.as_slice()[0].as_ref(), "third");
+    assert!(bucket.remove("third"));
+  }
+
+  #[test]
+  fn exact_bands_never_exclude_an_accepted_binary_signature() {
+    for width in 1..=6 {
+      for matching in 0..=width {
+        let boundary = ratio_usize(matching, width);
+        let below = f64::from_bits(boundary.to_bits().saturating_sub(1));
+        let above = f64::from_bits(boundary.to_bits() + 1);
+        for threshold in [below, boundary, above.min(1.0)] {
+          let band_count = exact_band_count(width, threshold);
+          let required = (0..=width)
+            .find(|&count| ratio_usize(count, width) >= threshold)
+            .unwrap();
+          assert_eq!(
+            band_count,
+            if required <= 1 {
+              0
+            } else {
+              width - required + 1
+            }
+          );
+          if band_count == 0 {
+            continue;
+          }
+          let signatures: Vec<Vec<u64>> = (0..1usize << width)
+            .map(|bits| {
+              (0..width).map(|lane| ((bits >> lane) & 1) as u64).collect()
+            })
+            .collect();
+          let bands: Vec<Vec<_>> = signatures
+            .iter()
+            .map(|values| signature_band_hashes(values, band_count).collect())
+            .collect();
+          for (left_index, left) in signatures.iter().enumerate() {
+            for (right_index, right) in signatures.iter().enumerate() {
+              let matches =
+                left.iter().zip(right).filter(|(a, b)| a == b).count();
+              if ratio_usize(matches, width) >= threshold {
+                assert!(bands[left_index]
+                  .iter()
+                  .zip(&bands[right_index])
+                  .any(|(a, b)| a == b));
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/inline_dedup/cminhash.rs
+++ b/src/inline_dedup/cminhash.rs
@@ -13,8 +13,6 @@ use std::sync::Arc;
 // Below this size, a linear scan is cheaper than constructing the band index.
 const MIN_INDEX_ENTRIES: usize = 128;
 
-const TOKEN_SET_TEMPLATE_ERROR: &str =
-  "internal error: token-set template initialization failed";
 const NUM_PERM_ADD_TOKEN_ENTRIES_ERROR: &str =
   "num_perm is not configured; initialize CMinHashDeduplicator with num_perm to add token-set entries";
 const NUM_PERM_CHECK_TOKEN_ENTRIES_ERROR: &str =
@@ -24,7 +22,6 @@ const NUM_PERM_QUERY_TOKEN_ENTRIES_ERROR: &str =
 
 #[derive(Default)]
 struct CMinHashTokenScratch {
-  template: Option<CMinHash>,
   scratch: Option<CMinHash>,
 }
 
@@ -36,23 +33,15 @@ impl CMinHashTokenScratch {
     seed: u64,
     token_hashes: &mut Vec<u64>,
   ) -> PyResult<&CMinHash> {
-    if self.template.is_none() {
-      let built = CMinHash::new(num_perm, seed)?;
-      self.scratch = Some(CMinHash::compact_from_template(&built));
-      self.template = Some(built);
-    }
+    let scratch = match &mut self.scratch {
+      Some(scratch) => scratch,
+      empty => empty.insert(CMinHash::new(num_perm, seed)?),
+    };
 
     token_hashes.clear();
     extend_token_hashes_from_document(document, token_hashes)?;
-    let Some(template_ref) = self.template.as_ref() else {
-      return Err(PyValueError::new_err(TOKEN_SET_TEMPLATE_ERROR));
-    };
-    let Some(scratch_ref) = self.scratch.as_mut() else {
-      return Err(PyValueError::new_err(TOKEN_SET_TEMPLATE_ERROR));
-    };
-    scratch_ref
-      .reset_from_token_hashes_with_template(token_hashes, template_ref);
-    Ok(scratch_ref)
+    scratch.reset_from_token_hashes(token_hashes);
+    Ok(scratch)
   }
 }
 
@@ -192,7 +181,7 @@ fn insert_signature_bands(
 ) {
   let key: Arc<str> = key.into();
   let hashes = signature_band_hashes(signature.signature_values(), index.len());
-  for (band, (_, hash)) in index.iter_mut().zip(hashes) {
+  for (band, hash) in index.iter_mut().zip(hashes) {
     band
       .entry(hash)
       .and_modify(|bucket| bucket.push(Arc::clone(&key)))
@@ -223,7 +212,7 @@ fn exact_band_count(num_perm: usize, threshold: f64) -> usize {
 fn signature_band_hashes(
   values: &[u64],
   band_count: usize,
-) -> impl Iterator<Item = (usize, u64)> + '_ {
+) -> impl Iterator<Item = u64> + '_ {
   let width = values.len() / band_count;
   let extra = values.len() % band_count;
   let mut start = 0;
@@ -232,7 +221,7 @@ fn signature_band_hashes(
     let mut hasher = FxHasher::default();
     values[start..end].hash(&mut hasher);
     start = end;
-    (band, hasher.finish())
+    hasher.finish()
   })
 }
 
@@ -243,7 +232,7 @@ impl CMinHashDeduplicator {
     let mut seen = FxHashSet::default();
     let hashes =
       signature_band_hashes(minhash.signature_values(), self.band_count);
-    for (band, (_, hash)) in self.signature_bands.iter().zip(hashes) {
+    for (band, hash) in self.signature_bands.iter().zip(hashes) {
       let Some(keys) = band.get(&hash) else {
         continue;
       };
@@ -450,7 +439,7 @@ impl CMinHashDeduplicator {
     if !self.signature_bands.is_empty() {
       let hashes =
         signature_band_hashes(removed.signature_values(), self.band_count);
-      for (band, (_, hash)) in self.signature_bands.iter_mut().zip(hashes) {
+      for (band, hash) in self.signature_bands.iter_mut().zip(hashes) {
         if let Some(keys) = band.get_mut(&hash) {
           if keys.remove(key) {
             band.remove(&hash);

--- a/src/inline_dedup/rminhash.rs
+++ b/src/inline_dedup/rminhash.rs
@@ -224,7 +224,6 @@ impl RMinHashDeduplicator {
   ///
   /// Returns an error when the supplied `RMinHash` has an incompatible configuration.
   pub fn add(&mut self, key: String, minhash: &RMinHash) -> PyResult<bool> {
-    self.validate_input_minhash(minhash)?;
     if self.is_duplicate(&key, minhash)? {
       return Ok(false);
     }

--- a/src/lsh.rs
+++ b/src/lsh.rs
@@ -1,7 +1,7 @@
 //! Locality-Sensitive Hashing (LSH) for `MinHash`.
 //!
 //! This module implements `RMinHashLSH`, a Locality-Sensitive Hashing scheme
-//! that uses `RMinHash` (Rensa's novel `MinHash` variant) to efficiently find
+//! that uses `RMinHash` signatures to efficiently find
 //! approximate nearest neighbors in large datasets. It's designed for identifying
 //! items with high Jaccard similarity.
 //!
@@ -36,7 +36,8 @@
 
 use pyo3::prelude::*;
 use rustc_hash::FxHasher;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 
@@ -56,7 +57,6 @@ const FX_FINISH_ROTATE: u32 = 26;
 const FX_FINISH_ROTATE: u32 = 15;
 
 /// `RMinHashLSH` implements Locality-Sensitive Hashing using `MinHash` for efficient similarity search.
-#[derive(Serialize)]
 #[pyclass(module = "rensa")]
 pub struct RMinHashLSH {
   threshold: f64,
@@ -66,16 +66,18 @@ pub struct RMinHashLSH {
   // These maps are keyed by internal band hashes / numeric IDs, not
   // attacker-controlled strings, so FxHasher is chosen for speed.
   hash_tables: Vec<HashMap<u64, Vec<usize>, BuildHasherDefault<FxHasher>>>,
-  #[serde(default)]
   key_bands: HashMap<usize, Vec<u64>, BuildHasherDefault<FxHasher>>,
-  #[serde(skip, default)]
   last_one_shot_sparse_verify_checks: usize,
-  #[serde(skip, default)]
   last_one_shot_sparse_verify_passes: usize,
 }
 
 #[derive(Deserialize)]
 struct RMinHashLSHState {
+  #[serde(
+    rename = "version",
+    deserialize_with = "crate::rminhash::deserialize_state_version"
+  )]
+  _version: (),
   threshold: f64,
   num_perm: usize,
   num_bands: usize,
@@ -85,13 +87,30 @@ struct RMinHashLSHState {
   key_bands: HashMap<usize, Vec<u64>, BuildHasherDefault<FxHasher>>,
 }
 
+impl Serialize for RMinHashLSH {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut state = serializer.serialize_struct("RMinHashLSH", 7)?;
+    state.serialize_field("version", &crate::rminhash::STATE_VERSION)?;
+    state.serialize_field("threshold", &self.threshold)?;
+    state.serialize_field("num_perm", &self.num_perm)?;
+    state.serialize_field("num_bands", &self.num_bands)?;
+    state.serialize_field("band_size", &self.band_size)?;
+    state.serialize_field("hash_tables", &self.hash_tables)?;
+    state.serialize_field("key_bands", &self.key_bands)?;
+    state.end()
+  }
+}
+
 impl<'de> Deserialize<'de> for RMinHashLSH {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where
     D: Deserializer<'de>,
   {
     let state = RMinHashLSHState::deserialize(deserializer)?;
-    Ok(Self {
+    let decoded = Self {
       threshold: state.threshold,
       num_perm: state.num_perm,
       num_bands: state.num_bands,
@@ -100,11 +119,73 @@ impl<'de> Deserialize<'de> for RMinHashLSH {
       key_bands: state.key_bands,
       last_one_shot_sparse_verify_checks: 0,
       last_one_shot_sparse_verify_passes: 0,
-    })
+    };
+    decoded
+      .validate_state_inner()
+      .map_err(serde::de::Error::custom)?;
+    Ok(decoded)
   }
 }
 
 impl RMinHashLSH {
+  fn validate_params_inner(
+    threshold: f64,
+    num_perm: usize,
+    num_bands: usize,
+  ) -> Result<usize, String> {
+    if !threshold.is_finite() || !(0.0..=1.0).contains(&threshold) {
+      return Err(
+        "threshold must be a finite value between 0.0 and 1.0".to_owned(),
+      );
+    }
+    if num_perm == 0 {
+      return Err("num_perm must be greater than 0".to_owned());
+    }
+    if num_bands == 0 {
+      return Err("num_bands must be greater than 0".to_owned());
+    }
+    if num_bands > num_perm {
+      return Err(format!(
+        "num_bands ({num_bands}) must be less than or equal to num_perm ({num_perm})"
+      ));
+    }
+    if num_perm % num_bands != 0 {
+      return Err(format!(
+        "num_perm ({num_perm}) must be divisible by num_bands ({num_bands})"
+      ));
+    }
+    Ok(num_perm / num_bands)
+  }
+
+  fn validate_state_inner(&self) -> Result<(), String> {
+    let expected_band_size = Self::validate_params_inner(
+      self.threshold,
+      self.num_perm,
+      self.num_bands,
+    )?;
+    if self.band_size != expected_band_size {
+      return Err(format!(
+        "invalid RMinHashLSH state: band_size {} does not match expected {}",
+        self.band_size, expected_band_size
+      ));
+    }
+    if self.hash_tables.len() != self.num_bands {
+      return Err(format!(
+        "invalid RMinHashLSH state: hash_tables length {} does not match num_bands {}",
+        self.hash_tables.len(), self.num_bands
+      ));
+    }
+    for (key, band_hashes) in &self.key_bands {
+      if band_hashes.len() != self.num_bands {
+        return Err(format!(
+          "invalid RMinHashLSH state: key {key} stores {} band hashes, expected {}",
+          band_hashes.len(), self.num_bands
+        ));
+      }
+    }
+    Ok(())
+  }
+
   #[inline]
   const fn fx_poly_steps(len_u32: usize) -> usize {
     // `calculate_band_hash` packs 4x u32 into 2x u64 writes, then writes any
@@ -124,3 +205,35 @@ impl RMinHashLSH {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod deserialization_tests {
+  use crate::lsh::RMinHashLSH;
+
+  #[test]
+  fn native_deserialization_rejects_invalid_index_dimensions() {
+    for invalid_field in 0..9 {
+      let mut index = RMinHashLSH::from_validated(0.8, 128, 8);
+      match invalid_field {
+        0 => index.threshold = f64::NAN,
+        1 => index.threshold = 1.1,
+        2 => index.num_perm = 0,
+        3 => index.num_bands = 0,
+        4 => index.num_bands = 129,
+        5 => index.num_perm = 129,
+        6 => index.band_size = 129,
+        7 => {
+          index.hash_tables.pop();
+        }
+        _ => {
+          index.key_bands.insert(0, vec![0; 7]);
+        }
+      }
+      let bytes = postcard::to_allocvec(&index).unwrap();
+      assert!(
+        postcard::from_bytes::<RMinHashLSH>(&bytes).is_err(),
+        "accepted invalid field {invalid_field}"
+      );
+    }
+  }
+}

--- a/src/lsh/config.rs
+++ b/src/lsh/config.rs
@@ -138,38 +138,12 @@ impl RMinHashLSH {
     ratio_usize(equal, signature_a.len())
   }
 
-  pub(in crate::lsh) fn validate_threshold(threshold: f64) -> PyResult<()> {
-    if !threshold.is_finite() || !(0.0..=1.0).contains(&threshold) {
-      return Err(PyValueError::new_err(
-        "threshold must be a finite value between 0.0 and 1.0",
-      ));
-    }
-    Ok(())
-  }
-
   pub(in crate::lsh) fn validate_params(
     threshold: f64,
     num_perm: usize,
     num_bands: usize,
   ) -> PyResult<usize> {
-    Self::validate_threshold(threshold)?;
-    if num_perm == 0 {
-      return Err(PyValueError::new_err("num_perm must be greater than 0"));
-    }
-    if num_bands == 0 {
-      return Err(PyValueError::new_err("num_bands must be greater than 0"));
-    }
-    if num_bands > num_perm {
-      return Err(PyValueError::new_err(format!(
-        "num_bands ({num_bands}) must be less than or equal to num_perm ({num_perm})"
-      )));
-    }
-    if num_perm % num_bands != 0 {
-      return Err(PyValueError::new_err(format!(
-        "num_perm ({num_perm}) must be divisible by num_bands ({num_bands})"
-      )));
-    }
-
-    Ok(num_perm / num_bands)
+    Self::validate_params_inner(threshold, num_perm, num_bands)
+      .map_err(PyValueError::new_err)
   }
 }

--- a/src/lsh/index.rs
+++ b/src/lsh/index.rs
@@ -120,12 +120,8 @@ impl RMinHashLSH {
     }
   }
 
-  pub(in crate::lsh) fn has_multiple_candidates(
-    &self,
-    digest: &[u32],
-    seen: &mut FxHashSet<usize>,
-  ) -> bool {
-    seen.clear();
+  pub(in crate::lsh) fn has_multiple_candidates(&self, digest: &[u32]) -> bool {
+    let mut first = None;
 
     for (i, table) in self.hash_tables.iter().enumerate() {
       let band_hash = calculate_band_hash(
@@ -133,9 +129,10 @@ impl RMinHashLSH {
       );
       if let Some(keys) = table.get(&band_hash) {
         for &key in keys {
-          if seen.insert(key) && seen.len() > 1 {
+          if first.is_some_and(|first_key| first_key != key) {
             return true;
           }
+          first = Some(key);
         }
       }
     }

--- a/src/lsh/index.rs
+++ b/src/lsh/index.rs
@@ -29,34 +29,6 @@ impl RMinHashLSH {
     }
   }
 
-  pub(in crate::lsh) fn validate_state(&self) -> PyResult<()> {
-    let expected_band_size =
-      Self::validate_params(self.threshold, self.num_perm, self.num_bands)?;
-    if self.band_size != expected_band_size {
-      return Err(PyValueError::new_err(format!(
-        "invalid RMinHashLSH state: band_size {} does not match expected {}",
-        self.band_size, expected_band_size
-      )));
-    }
-    if self.hash_tables.len() != self.num_bands {
-      return Err(PyValueError::new_err(format!(
-        "invalid RMinHashLSH state: hash_tables length {} does not match num_bands {}",
-        self.hash_tables.len(),
-        self.num_bands
-      )));
-    }
-    for (key, band_hashes) in &self.key_bands {
-      if band_hashes.len() != self.num_bands {
-        return Err(PyValueError::new_err(format!(
-          "invalid RMinHashLSH state: key {key} stores {} band hashes, expected {}",
-          band_hashes.len(),
-          self.num_bands
-        )));
-      }
-    }
-    Ok(())
-  }
-
   pub(in crate::lsh) fn ensure_digest_len(
     &self,
     digest_len: usize,

--- a/src/lsh/one_shot.rs
+++ b/src/lsh/one_shot.rs
@@ -177,15 +177,19 @@ fn count_scan_band(
   bucket_state_by_hash.clear();
   for row_index in 0..raw.rows {
     let band_hash = raw.get(row_index, band_idx);
-    if let Some(state) = bucket_state_by_hash.get_mut(&band_hash) {
-      if *state & RESCUE_COLLIDED_BIT == 0 {
-        let first_row = rescue_state_first_row(*state);
-        *state |= RESCUE_COLLIDED_BIT;
-        raw_match_counts[first_row].fetch_add(1, Ordering::Relaxed);
+    match bucket_state_by_hash.entry(band_hash) {
+      Entry::Vacant(entry) => {
+        entry.insert(usize_to_u64_lowbits(row_index));
       }
-      raw_match_counts[row_index].fetch_add(1, Ordering::Relaxed);
-    } else {
-      bucket_state_by_hash.insert(band_hash, usize_to_u64_lowbits(row_index));
+      Entry::Occupied(mut entry) => {
+        let state = entry.get_mut();
+        if *state & RESCUE_COLLIDED_BIT == 0 {
+          let first_row = rescue_state_first_row(*state);
+          *state |= RESCUE_COLLIDED_BIT;
+          raw_match_counts[first_row].fetch_add(1, Ordering::Relaxed);
+        }
+        raw_match_counts[row_index].fetch_add(1, Ordering::Relaxed);
+      }
     }
   }
 }
@@ -772,11 +776,14 @@ impl RMinHashLSH {
         {
           flags[row_index] = true;
         }
-        if let Some(&first_row) = first_row_by_hash.get(&band_hash) {
-          flags[row_index] = true;
-          flags[first_row] = true;
-        } else {
-          first_row_by_hash.insert(band_hash, row_index);
+        match first_row_by_hash.entry(band_hash) {
+          Entry::Vacant(entry) => {
+            entry.insert(row_index);
+          }
+          Entry::Occupied(entry) => {
+            flags[row_index] = true;
+            flags[*entry.get()] = true;
+          }
         }
       }
     }
@@ -870,6 +877,35 @@ impl RMinHashLSH {
   ) -> (usize, usize) {
     let mut sparse_verify_checks = 0usize;
     let mut sparse_verify_passes = 0usize;
+
+    if let &[left, right] = members {
+      let left = left as usize;
+      let right = right as usize;
+      let needs_verify = ctx.sparse_verify.enabled
+        && (ctx.required_band_matches[left] > 1
+          || ctx.required_band_matches[right] > 1);
+      let matched = if needs_verify {
+        if ctx.sparse_verify.max_candidates == 0 {
+          return (0, 0);
+        }
+        sparse_verify_checks = 2;
+        let passed = Self::sparse_verify_pair_passes(
+          ctx.digest_matrix,
+          left,
+          right,
+          ctx.sparse_verify.threshold,
+        );
+        sparse_verify_passes = if passed { 2 } else { 0 };
+        passed
+      } else {
+        true
+      };
+      if matched {
+        band_match_counts[left].fetch_add(1, Ordering::Relaxed);
+        band_match_counts[right].fetch_add(1, Ordering::Relaxed);
+      }
+      return (sparse_verify_checks, sparse_verify_passes);
+    }
 
     for &row_index in members {
       let row_index = row_index as usize;
@@ -994,19 +1030,24 @@ impl RMinHashLSH {
         },
         |precomputed| precomputed.hashes[row_index * self.num_bands + band_idx],
       );
-      if let Some(bucket_state) = bucket_state_by_hash.get_mut(&band_hash) {
-        if *bucket_state & RESCUE_COLLIDED_BIT == 0 {
-          let first_row = rescue_state_first_row(*bucket_state);
-          *bucket_state |= RESCUE_COLLIDED_BIT;
-          if rescue_candidate_mask[first_row] == 1 {
-            rescue_band_match_counts[first_row].fetch_add(1, Ordering::Relaxed);
+      match bucket_state_by_hash.entry(band_hash) {
+        Entry::Vacant(entry) => {
+          entry.insert(usize_to_u64_lowbits(row_index));
+        }
+        Entry::Occupied(mut entry) => {
+          let bucket_state = entry.get_mut();
+          if *bucket_state & RESCUE_COLLIDED_BIT == 0 {
+            let first_row = rescue_state_first_row(*bucket_state);
+            *bucket_state |= RESCUE_COLLIDED_BIT;
+            if rescue_candidate_mask[first_row] == 1 {
+              rescue_band_match_counts[first_row]
+                .fetch_add(1, Ordering::Relaxed);
+            }
+          }
+          if *rescue_candidate == 1 {
+            rescue_band_match_counts[row_index].fetch_add(1, Ordering::Relaxed);
           }
         }
-        if *rescue_candidate == 1 {
-          rescue_band_match_counts[row_index].fetch_add(1, Ordering::Relaxed);
-        }
-      } else {
-        bucket_state_by_hash.insert(band_hash, usize_to_u64_lowbits(row_index));
       }
     }
   }
@@ -1084,6 +1125,119 @@ impl RMinHashLSH {
         band_match_counts[row_index]
           .store(required_band_matches[row_index], Ordering::Relaxed);
       }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::lsh::one_shot::{
+    atomic_counters, count_scan_band, GroupVerifyContext, RawBandHashes,
+    SparseVerifyConfig,
+  };
+  use crate::lsh::RMinHashLSH;
+  use crate::rminhash::RMinHashDigestMatrix;
+  use rustc_hash::FxHashMap;
+  use std::sync::atomic::Ordering;
+
+  #[test]
+  fn two_member_verification_preserves_counts_and_statistics() {
+    for enabled in [false, true] {
+      for max_candidates in [0, 1, 4] {
+        for required in [[1, 1], [1, 2], [2, 1], [2, 2]] {
+          for active in [vec![1, 1], vec![1, 0], vec![0, 1]] {
+            for matching in [false, true] {
+              let signatures = if matching {
+                vec![7, 8, 7, 8]
+              } else {
+                vec![7, 8, 9, 10]
+              };
+              let matrix = RMinHashDigestMatrix::test_matrix(
+                1,
+                vec![0, 0],
+                signatures,
+                active.clone(),
+              );
+              let config = SparseVerifyConfig {
+                enabled,
+                threshold: 0.75,
+                max_candidates,
+              };
+              let ctx = GroupVerifyContext {
+                digest_matrix: &matrix,
+                required_band_matches: &required,
+                sparse_verify: &config,
+              };
+              let counters = atomic_counters(2);
+              let actual =
+                RMinHashLSH::process_collision_group(&ctx, &[0, 1], &counters);
+              let needs_verify = enabled && required.contains(&2);
+              let checked = needs_verify && max_candidates > 0;
+              let passed = matching || active.contains(&0);
+              let matched = !needs_verify || (checked && passed);
+              assert_eq!(
+                actual,
+                (usize::from(checked) * 2, usize::from(checked && passed) * 2)
+              );
+              for counter in &counters {
+                assert_eq!(counter.load(Ordering::Relaxed), u32::from(matched));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn band_counts_count_each_colliding_row_once_and_reset_scratch() {
+    let raw = RawBandHashes {
+      num_bands: 2,
+      rows: 5,
+      hashes: vec![10, 1, 10, 2, 10, 3, 20, 4, 30, 4],
+    };
+    let counters = atomic_counters(raw.rows);
+    let mut scratch = FxHashMap::default();
+    count_scan_band(&raw, 0, &counters, &mut scratch);
+    count_scan_band(&raw, 1, &counters, &mut scratch);
+    let counts: Vec<_> = counters
+      .iter()
+      .map(|count| count.load(Ordering::Relaxed))
+      .collect();
+    assert_eq!(counts, vec![1, 1, 1, 1, 1]);
+  }
+
+  #[test]
+  fn simple_flags_and_rescue_counts_preserve_first_and_later_members() {
+    let matrix = RMinHashDigestMatrix::test_matrix(
+      1,
+      vec![10, 10, 10, 20, 30],
+      Vec::new(),
+      Vec::new(),
+    );
+    let lsh = RMinHashLSH::from_validated(0.5, 1, 1);
+    assert_eq!(
+      lsh.simple_one_shot_flags(&matrix, 5, 1, 1, 1, false),
+      vec![true, true, true, false, false],
+    );
+    for mask in [[1, 0, 1, 1, 1], [0, 1, 1, 1, 1]] {
+      let counters = atomic_counters(5);
+      lsh.recall_rescue_band_counts(
+        &matrix,
+        None,
+        0,
+        &mask,
+        &counters,
+        &mut FxHashMap::default(),
+      );
+      let counts: Vec<_> = counters
+        .iter()
+        .map(|count| count.load(Ordering::Relaxed))
+        .collect();
+      assert_eq!(
+        counts,
+        vec![u32::from(mask[0]), u32::from(mask[1]), 1, 0, 0]
+      );
     }
   }
 }

--- a/src/lsh/one_shot.rs
+++ b/src/lsh/one_shot.rs
@@ -469,13 +469,22 @@ impl RMinHashLSH {
     let raw = self.compute_raw_band_hashes(digest_matrix, rows)?;
 
     let band_match_counts = atomic_counters(rows);
-    let raw_match_counts = if recall_rescue.enabled {
+    let needs_rescue = recall_rescue.enabled
+      && (0..rows).any(|row| {
+        required_band_matches[row] == 1
+          && digest_matrix
+            .rho_source_token_count(row)
+            .is_some_and(|count| {
+              count >= recall_rescue.min_tokens
+                && count <= recall_rescue.max_tokens
+            })
+      });
+    let raw_match_counts = if needs_rescue {
       atomic_counters(rows)
     } else {
       Vec::new()
     };
-    let raw_counts_ref =
-      recall_rescue.enabled.then_some(raw_match_counts.as_slice());
+    let raw_counts_ref = needs_rescue.then_some(raw_match_counts.as_slice());
 
     let rest_bands: Vec<usize> = (0..self.num_bands)
       .filter(|band_idx| band_idx % fold != 0)
@@ -554,7 +563,7 @@ impl RMinHashLSH {
       sparse_verify_passes = sparse_verify_passes.saturating_add(passes);
     }
 
-    if recall_rescue.enabled {
+    if needs_rescue {
       let required_matches =
         u32::try_from(recall_rescue.required_band_matches).unwrap_or(u32::MAX);
       for row_index in 0..rows {
@@ -1132,8 +1141,8 @@ impl RMinHashLSH {
 #[cfg(test)]
 mod tests {
   use crate::lsh::one_shot::{
-    atomic_counters, count_scan_band, GroupVerifyContext, RawBandHashes,
-    SparseVerifyConfig,
+    atomic_counters, count_scan_band, window_rest_key, BandFoldingConfig,
+    GroupVerifyContext, RawBandHashes, RecallRescueConfig, SparseVerifyConfig,
   };
   use crate::lsh::RMinHashLSH;
   use crate::rminhash::RMinHashDigestMatrix;
@@ -1239,5 +1248,173 @@ mod tests {
         vec![u32::from(mask[0]), u32::from(mask[1]), 1, 0, 0]
       );
     }
+  }
+
+  // Independent eager reference: count raw collisions against every other row,
+  // and group complete folded keys directly before applying rescue.
+  fn eager_grouped_reference(
+    lsh: &RMinHashLSH,
+    matrix: &RMinHashDigestMatrix,
+    folding: &BandFoldingConfig,
+    required: &[u32],
+    verify: &SparseVerifyConfig,
+    rescue: &RecallRescueConfig,
+  ) -> (Vec<bool>, usize, usize) {
+    let rows = matrix.rows();
+    let raw = lsh.compute_raw_band_hashes(matrix, rows).unwrap();
+    let counters = atomic_counters(rows);
+    let context = GroupVerifyContext {
+      digest_matrix: matrix,
+      required_band_matches: required,
+      sparse_verify: verify,
+    };
+    let mut stats = (0, 0);
+    for window in 0..folding.effective_num_bands {
+      let first = window * folding.rho_band_fold;
+      let mut groups: FxHashMap<(u64, u64), Vec<u32>> = FxHashMap::default();
+      for row in 0..rows {
+        groups
+          .entry((
+            raw.get(row, first),
+            window_rest_key(&raw, first, folding.rho_band_fold, row),
+          ))
+          .or_default()
+          .push(u32::try_from(row).unwrap());
+      }
+      for members in groups.values().filter(|members| members.len() > 1) {
+        let (checks, passes) =
+          RMinHashLSH::process_collision_group(&context, members, &counters);
+        stats.0 += checks;
+        stats.1 += passes;
+      }
+    }
+    let flags = (0..rows)
+      .map(|row| {
+        let matches = counters[row].load(Ordering::Relaxed);
+        let eligible = rescue.enabled
+          && matches == 0
+          && required[row] == 1
+          && matrix.rho_source_token_count(row).is_some_and(|count| {
+            count >= rescue.min_tokens && count <= rescue.max_tokens
+          });
+        let raw_matches = (0..lsh.num_bands)
+          .filter(|&band| {
+            (0..rows).any(|other| {
+              other != row && raw.get(row, band) == raw.get(other, band)
+            })
+          })
+          .count();
+        matches >= required[row]
+          || (eligible && raw_matches >= rescue.required_band_matches)
+      })
+      .collect();
+    (flags, stats.0, stats.1)
+  }
+
+  #[test]
+  fn rescue_eligibility_matches_eager_flags_and_verification_statistics() {
+    let lsh = RMinHashLSH::from_validated(0.5, 4, 4);
+    let corpora = [
+      // No collisions; eligible candidates require rescue scans.
+      vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+      // Every row already has folded matches.
+      vec![1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
+      // First-band collisions alone meet a rescue threshold of two.
+      vec![1, 2, 3, 4, 1, 6, 3, 8, 9, 10, 11, 12, 9, 14, 11, 16],
+      // Only second bands collide; sparse rows must remain partners.
+      vec![1, 2, 3, 4, 5, 2, 7, 4, 9, 10, 11, 12, 13, 10, 15, 12],
+    ];
+    for data in corpora {
+      let matrix = RMinHashDigestMatrix::test_matrix(
+        4,
+        data,
+        vec![7, 8, 7, 8, 9, 10, 11, 12],
+        vec![1, 1, 1, 0],
+      );
+      for fold in [2, 4] {
+        let folding = BandFoldingConfig {
+          rho_band_fold: fold,
+          effective_num_bands: 4 / fold,
+          effective_band_size: fold,
+        };
+        for required in [[1, 1, 1, 1], [1, 2, 1, 2], [2, 2, 2, 2]] {
+          for (enabled, max_candidates) in
+            [(false, 1), (true, 0), (true, 1), (true, 4)]
+          {
+            let verify = SparseVerifyConfig {
+              enabled,
+              threshold: 0.75,
+              max_candidates,
+            };
+            for (enabled, min_tokens, max_tokens) in
+              [(false, 1, 1), (true, 1, 1), (true, 2, 3), (true, 0, 0)]
+            {
+              for required_band_matches in [1, 2, 4] {
+                let rescue = RecallRescueConfig {
+                  enabled,
+                  min_tokens,
+                  max_tokens,
+                  required_band_matches,
+                };
+                assert_eq!(
+                  lsh.grouped_one_shot_flags(
+                    &matrix,
+                    matrix.rows(),
+                    &folding,
+                    &required,
+                    &verify,
+                    &rescue
+                  ),
+                  Some(eager_grouped_reference(
+                    &lsh, &matrix, &folding, &required, &verify, &rescue
+                  )),
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn rescue_eligibility_large_batch_keeps_ineligible_collision_partners() {
+    let rows = 2048;
+    let data = (0..rows)
+      .flat_map(|row| {
+        let value = u32::try_from(row).unwrap();
+        [value, 17, value, 19]
+      })
+      .collect();
+    let matrix =
+      RMinHashDigestMatrix::test_matrix(4, data, vec![7; rows], vec![1; rows]);
+    let lsh = RMinHashLSH::from_validated(0.5, 4, 4);
+    let folding = BandFoldingConfig {
+      rho_band_fold: 2,
+      effective_num_bands: 2,
+      effective_band_size: 2,
+    };
+    let required: Vec<_> = (0..rows)
+      .map(|row| if row % 2 == 0 { 1 } else { 2 })
+      .collect();
+    let verify = SparseVerifyConfig {
+      enabled: true,
+      threshold: 0.75,
+      max_candidates: 1,
+    };
+    let rescue = RecallRescueConfig {
+      enabled: true,
+      min_tokens: 1,
+      max_tokens: 1,
+      required_band_matches: 2,
+    };
+    assert_eq!(
+      lsh.grouped_one_shot_flags(
+        &matrix, rows, &folding, &required, &verify, &rescue
+      ),
+      Some(eager_grouped_reference(
+        &lsh, &matrix, &folding, &required, &verify, &rescue
+      )),
+    );
   }
 }

--- a/src/lsh/py.rs
+++ b/src/lsh/py.rs
@@ -11,6 +11,8 @@ fn checked_key(start_key: usize, offset: usize) -> PyResult<usize> {
   })
 }
 
+const PY_STATE_PREFIX: &[u8] = b"Rensa:RMinHashLSH:2\0";
+
 #[pymethods]
 impl RMinHashLSH {
   /// Creates a new `RMinHashLSH` instance.
@@ -347,13 +349,16 @@ impl RMinHashLSH {
   }
 
   fn __setstate__(&mut self, state: &Bound<'_, PyBytes>) -> PyResult<()> {
-    let decoded: Self =
-      postcard::from_bytes(state.as_bytes()).map_err(|err| {
-        PyValueError::new_err(format!(
-          "failed to deserialize RMinHashLSH state: {err}"
-        ))
-      })?;
-    decoded.validate_state()?;
+    let payload = state.as_bytes().strip_prefix(PY_STATE_PREFIX).ok_or_else(|| {
+      PyValueError::new_err(
+        "unsupported RMinHashLSH state version; rebuild the index from its tokens",
+      )
+    })?;
+    let decoded: Self = postcard::from_bytes(payload).map_err(|err| {
+      PyValueError::new_err(format!(
+        "failed to deserialize RMinHashLSH state: {err}"
+      ))
+    })?;
     *self = decoded;
     Ok(())
   }
@@ -362,11 +367,12 @@ impl RMinHashLSH {
     &self,
     py: Python<'py>,
   ) -> PyResult<Bound<'py, PyBytes>> {
-    let encoded = postcard::to_allocvec(self).map_err(|err| {
-      PyValueError::new_err(format!(
-        "failed to serialize RMinHashLSH state: {err}"
-      ))
-    })?;
+    let encoded =
+      postcard::to_extend(self, PY_STATE_PREFIX.to_vec()).map_err(|err| {
+        PyValueError::new_err(format!(
+          "failed to serialize RMinHashLSH state: {err}"
+        ))
+      })?;
     Ok(PyBytes::new(py, &encoded))
   }
 

--- a/src/lsh/py.rs
+++ b/src/lsh/py.rs
@@ -5,6 +5,12 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyBytes, PyIterator};
 use rustc_hash::FxHashSet;
 
+fn checked_key(start_key: usize, offset: usize) -> PyResult<usize> {
+  start_key.checked_add(offset).ok_or_else(|| {
+    PyValueError::new_err("start_key + offset exceeds the maximum key")
+  })
+}
+
 #[pymethods]
 impl RMinHashLSH {
   /// Creates a new `RMinHashLSH` instance.
@@ -68,7 +74,7 @@ impl RMinHashLSH {
   /// # Errors
   ///
   /// Returns an error if `minhashes` is not iterable, if an item is not an
-  /// `RMinHash`, or if a `minhash` has incompatible parameters.
+  /// `RMinHash`, if a `minhash` has incompatible parameters, or if a key overflows.
   #[pyo3(signature = (minhashes, start_key=0))]
   pub fn insert_many(
     &mut self,
@@ -78,7 +84,10 @@ impl RMinHashLSH {
     let iterator = PyIterator::from_object(minhashes)?;
     for (offset, minhash) in iterator.enumerate() {
       let minhash: PyRef<'_, RMinHash> = minhash?.extract()?;
-      self.insert_digest(start_key + offset, minhash.hash_values())?;
+      self.insert_digest(
+        checked_key(start_key, offset)?,
+        minhash.hash_values(),
+      )?;
     }
     Ok(())
   }
@@ -89,7 +98,7 @@ impl RMinHashLSH {
   ///
   /// # Errors
   ///
-  /// Returns an error when `num_perm` does not match this index.
+  /// Returns an error when `num_perm` does not match this index or a key overflows.
   #[pyo3(signature = (digest_matrix, start_key=0))]
   pub fn insert_matrix(
     &mut self,
@@ -97,6 +106,7 @@ impl RMinHashLSH {
     start_key: usize,
   ) -> PyResult<()> {
     self.ensure_digest_len(digest_matrix.num_perm())?;
+    checked_key(start_key, digest_matrix.rows().saturating_sub(1))?;
     self.key_bands.reserve(digest_matrix.rows());
     for table in &mut self.hash_tables {
       table.reserve(digest_matrix.rows());
@@ -114,7 +124,7 @@ impl RMinHashLSH {
   ///
   /// # Errors
   ///
-  /// Returns an error when `num_perm` does not match this index.
+  /// Returns an error when `num_perm` does not match this index or a key overflows.
   #[pyo3(signature = (digest_matrix, start_key=0))]
   pub fn insert_matrix_and_query_duplicate_flags(
     &mut self,
@@ -123,6 +133,7 @@ impl RMinHashLSH {
   ) -> PyResult<Vec<bool>> {
     self.ensure_digest_len(digest_matrix.num_perm())?;
     let rows = digest_matrix.rows();
+    checked_key(start_key, rows.saturating_sub(1))?;
     self.key_bands.reserve(rows);
     for table in &mut self.hash_tables {
       table.reserve(rows);
@@ -242,13 +253,12 @@ impl RMinHashLSH {
     let capacity = minhashes.len().unwrap_or_default();
     let iterator = PyIterator::from_object(minhashes)?;
     let mut flags = Vec::with_capacity(capacity);
-    let mut seen = FxHashSet::default();
 
     for minhash in iterator {
       let minhash: PyRef<'_, RMinHash> = minhash?.extract()?;
       let digest = minhash.hash_values();
       self.ensure_digest_len(digest.len())?;
-      flags.push(self.has_multiple_candidates(digest, &mut seen));
+      flags.push(self.has_multiple_candidates(digest));
     }
 
     Ok(flags)
@@ -265,12 +275,9 @@ impl RMinHashLSH {
   ) -> PyResult<Vec<bool>> {
     self.ensure_digest_len(digest_matrix.num_perm())?;
     let mut flags = Vec::with_capacity(digest_matrix.rows());
-    let mut seen = FxHashSet::default();
 
     for row_index in 0..digest_matrix.rows() {
-      flags.push(
-        self.has_multiple_candidates(digest_matrix.row(row_index), &mut seen),
-      );
+      flags.push(self.has_multiple_candidates(digest_matrix.row(row_index)));
     }
 
     Ok(flags)

--- a/src/py_input.rs
+++ b/src/py_input.rs
@@ -1,3 +1,4 @@
+use pyo3::buffer::PyUntypedBuffer;
 use pyo3::ffi;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyIterator, PyList, PyTuple};
@@ -15,11 +16,23 @@ const TOKEN_TYPE_ERROR: &str =
   "each item must be str, bytes, bytearray, or a C-contiguous u8 buffer";
 const BYTE_TOKEN_TYPE_ERROR: &str =
   "each item must be bytes, bytearray, or a C-contiguous u8 buffer";
-const PREHASHED_TOKEN_TYPE_ERROR: &str =
+pub const PREHASHED_TOKEN_TYPE_ERROR: &str =
   "each item must be an unsigned 64-bit integer";
 const BUFFER_TYPE_ERROR: &str =
   "buffer inputs must be C-contiguous and byte-sized (u8)";
 const SEQUENCE_SIZE_ERROR: &str = "sequence size does not fit in usize";
+
+pub fn buffer_has_native_byte_order(buffer: &PyUntypedBuffer) -> bool {
+  if buffer.item_size() == 1 {
+    return true;
+  }
+  // PyO3 0.29 accepts big-endian formats on little-endian hosts.
+  match buffer.format().to_bytes().first() {
+    Some(b'<') => cfg!(target_endian = "little"),
+    Some(b'>' | b'!') => cfg!(target_endian = "big"),
+    _ => true,
+  }
+}
 
 pub fn hash_token(item: &Bound<'_, PyAny>) -> PyResult<u64> {
   ptr_hash::hash_token_ptr(item.py(), item.as_ptr())
@@ -136,9 +149,16 @@ pub fn extend_prehashed_token_values_from_document(
   if prehashed::try_extend_prehashed_u64_buffer(document, output)? {
     return Ok(());
   }
+  extend_prehashed_token_values_from_iterable(document, output)
+}
 
+pub fn extend_prehashed_token_values_from_iterable(
+  document: &Bound<'_, PyAny>,
+  output: &mut Vec<u64>,
+) -> PyResult<()> {
   if let Ok(py_list) = document.cast::<PyList>() {
-    // SAFETY: list access is guarded by CPython list checks and GIL.
+    // SAFETY: CPython list checks and the GIL guard access. The unsigned
+    // conversion requires a PyLongObject and does not call Python __index__.
     unsafe {
       let object_ptr = py_list.as_ptr();
       let length = ffi::PyList_GET_SIZE(object_ptr);

--- a/src/py_input/fast_sequence.rs
+++ b/src/py_input/fast_sequence.rs
@@ -34,16 +34,18 @@ enum TokenHashMode {
   Generic,
 }
 
+// Cached specialized types must be immortal built-ins: a callback can replace
+// list contents without changing length and release a heap-defined subclass.
 impl TokenHashMode {
   #[inline]
   unsafe fn from_first_item(first_item: *mut ffi::PyObject) -> Self {
-    if ffi::PyUnicode_Check(first_item) != 0 {
+    if ffi::PyUnicode_CheckExact(first_item) != 0 {
       return Self::Unicode;
     }
-    if ffi::PyBytes_Check(first_item) != 0 {
+    if ffi::PyBytes_CheckExact(first_item) != 0 {
       return Self::Bytes;
     }
-    if ffi::PyByteArray_Check(first_item) != 0 {
+    if ffi::PyByteArray_CheckExact(first_item) != 0 {
       return Self::ByteArray;
     }
     Self::Generic
@@ -60,10 +62,10 @@ enum ByteTokenHashMode {
 impl ByteTokenHashMode {
   #[inline]
   unsafe fn from_first_item(first_item: *mut ffi::PyObject) -> Self {
-    if ffi::PyBytes_Check(first_item) != 0 {
+    if ffi::PyBytes_CheckExact(first_item) != 0 {
       return Self::Bytes;
     }
-    if ffi::PyByteArray_Check(first_item) != 0 {
+    if ffi::PyByteArray_CheckExact(first_item) != 0 {
       return Self::ByteArray;
     }
     Self::Generic
@@ -103,6 +105,25 @@ where
     for_each_token_hash_in_sequence(py, kind, object_ptr, visitor)?;
   }
   Ok(true)
+}
+
+// Only the generic token path can invoke a Python buffer exporter, which may
+// resize the list. Keep built-in token loops fast, but revalidate after callbacks.
+#[inline]
+unsafe fn hash_list_item(
+  py: Python<'_>,
+  list: *mut ffi::PyObject,
+  length: ffi::Py_ssize_t,
+  item: *mut ffi::PyObject,
+  hash: fn(Python<'_>, *mut ffi::PyObject) -> PyResult<u64>,
+) -> PyResult<u64> {
+  let value = hash(py, item)?;
+  if ffi::PyList_GET_SIZE(list) != length {
+    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+      "token list changed size during hashing",
+    ));
+  }
+  Ok(value)
 }
 
 unsafe fn for_each_token_hash_in_sequence<F>(
@@ -150,7 +171,7 @@ where
         visitor(if item_type_ptr == first_type_ptr {
           hash_unicode_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         })?;
         index += 1;
       }
@@ -162,7 +183,7 @@ where
         visitor(if item_type_ptr == first_type_ptr {
           hash_bytes_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         })?;
         index += 1;
       }
@@ -174,7 +195,7 @@ where
         visitor(if item_type_ptr == first_type_ptr {
           hash_bytearray_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         })?;
         index += 1;
       }
@@ -182,7 +203,13 @@ where
     TokenHashMode::Generic => {
       while index < length {
         let item_ptr = ffi::PyList_GET_ITEM(object_ptr, index);
-        visitor(hash_token_ptr(py, item_ptr)?)?;
+        visitor(hash_list_item(
+          py,
+          object_ptr,
+          length,
+          item_ptr,
+          hash_token_ptr,
+        )?)?;
         index += 1;
       }
     }
@@ -294,7 +321,7 @@ unsafe fn extend_tokens_from_list(
         output.push(if item_type_ptr == first_type_ptr {
           hash_unicode_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         });
         index += 1;
       }
@@ -306,7 +333,7 @@ unsafe fn extend_tokens_from_list(
         output.push(if item_type_ptr == first_type_ptr {
           hash_bytes_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         });
         index += 1;
       }
@@ -318,7 +345,7 @@ unsafe fn extend_tokens_from_list(
         output.push(if item_type_ptr == first_type_ptr {
           hash_bytearray_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         });
         index += 1;
       }
@@ -326,7 +353,13 @@ unsafe fn extend_tokens_from_list(
     TokenHashMode::Generic => {
       while index < length {
         let item_ptr = ffi::PyList_GET_ITEM(object_ptr, index);
-        output.push(hash_token_ptr(py, item_ptr)?);
+        output.push(hash_list_item(
+          py,
+          object_ptr,
+          length,
+          item_ptr,
+          hash_token_ptr,
+        )?);
         index += 1;
       }
     }
@@ -521,7 +554,7 @@ unsafe fn extend_tokens_from_list_sampled(
         output.push(if item_type_ptr == first_type_ptr {
           hash_unicode_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         });
       }
     }
@@ -536,7 +569,7 @@ unsafe fn extend_tokens_from_list_sampled(
         output.push(if item_type_ptr == first_type_ptr {
           hash_bytes_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         });
       }
     }
@@ -551,7 +584,7 @@ unsafe fn extend_tokens_from_list_sampled(
         output.push(if item_type_ptr == first_type_ptr {
           hash_bytearray_ptr(py, item_ptr)?
         } else {
-          hash_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_token_ptr)?
         });
       }
     }
@@ -562,7 +595,13 @@ unsafe fn extend_tokens_from_list_sampled(
         #[allow(clippy::cast_possible_wrap)]
         let index_ssize = index as ffi::Py_ssize_t;
         let item_ptr = ffi::PyList_GET_ITEM(object_ptr, index_ssize);
-        output.push(hash_token_ptr(py, item_ptr)?);
+        output.push(hash_list_item(
+          py,
+          object_ptr,
+          length,
+          item_ptr,
+          hash_token_ptr,
+        )?);
       }
     }
   }
@@ -707,7 +746,7 @@ unsafe fn extend_byte_tokens_from_list(
         output.push(if item_type_ptr == first_type_ptr {
           hash_bytes_ptr(py, item_ptr)?
         } else {
-          hash_byte_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_byte_token_ptr)?
         });
         index += 1;
       }
@@ -719,7 +758,7 @@ unsafe fn extend_byte_tokens_from_list(
         output.push(if item_type_ptr == first_type_ptr {
           hash_bytearray_ptr(py, item_ptr)?
         } else {
-          hash_byte_token_ptr(py, item_ptr)?
+          hash_list_item(py, object_ptr, length, item_ptr, hash_byte_token_ptr)?
         });
         index += 1;
       }
@@ -727,7 +766,13 @@ unsafe fn extend_byte_tokens_from_list(
     ByteTokenHashMode::Generic => {
       while index < length {
         let item_ptr = ffi::PyList_GET_ITEM(object_ptr, index);
-        output.push(hash_byte_token_ptr(py, item_ptr)?);
+        output.push(hash_list_item(
+          py,
+          object_ptr,
+          length,
+          item_ptr,
+          hash_byte_token_ptr,
+        )?);
         index += 1;
       }
     }

--- a/src/py_input/prehashed.rs
+++ b/src/py_input/prehashed.rs
@@ -25,7 +25,9 @@ pub fn try_extend_prehashed_u64_buffer(
   let Ok(buffer) = PyBuffer::<u64>::get(document) else {
     return Ok(false);
   };
-  if !buffer.is_c_contiguous() {
+  if !buffer.is_c_contiguous()
+    || !crate::py_input::buffer_has_native_byte_order(&buffer)
+  {
     return Err(crate::py_input::convert::py_err_to_type_error(
       crate::py_input::PREHASHED_TOKEN_TYPE_ERROR,
     ));

--- a/src/rminhash.rs
+++ b/src/rminhash.rs
@@ -239,6 +239,12 @@ impl RMinHash {
         self.num_perm, other.num_perm
       )));
     }
+    if self.seed != other.seed {
+      return Err(PyValueError::new_err(format!(
+        "seed mismatch: left is {}, right is {}",
+        self.seed, other.seed
+      )));
+    }
     Ok(())
   }
 

--- a/src/rminhash.rs
+++ b/src/rminhash.rs
@@ -1,42 +1,26 @@
-//! Implementation of the R-MinHash algorithm, a novel variant of `MinHash`.
-//! R-MinHash is designed for high-performance similarity estimation and deduplication
-//! of large datasets, forming a core component of the Rensa library.
+//! Seeded `MinHash` sketches for similarity estimation and deduplication.
 //!
-//! This algorithm represents an original approach developed for Rensa. It draws
-//! inspiration from traditional `MinHash` techniques and concepts discussed in
-//! the context of algorithms like C-MinHash, but implements a distinct and
-//! simplified method for generating `MinHash` signatures.
+//! R-MinHash uses Rensa's practical pseudorandom hash family. Its scalar and
+//! batch entry points produce the same signature and support incremental
+//! updates. Rho is a separate bucket sketch used by the fast deduplication
+//! pipeline; its output is not interchangeable with an R-MinHash signature.
 //!
-//! For context on related advanced `MinHash` techniques, see:
-//! - C-MinHash: Rigorously Reducing K Permutations to Two.
-//!   Ping Li, Arnd Christian König. [arXiv:2109.03337](https://arxiv.org/abs/2109.03337)
-//!
-//! Key characteristics of R-MinHash:
-//! - Simulates `num_perm` independent hash functions using unique pairs of random
-//!   numbers (a, b) for each permutation, applied on-the-fly. This avoids
-//!   storing full permutations or complex derivation schemes.
-//! - Optimized for speed using batch processing of input items and leveraging
-//!   efficient hash computations.
-//! - Provides a practical balance between performance and accuracy for large-scale
-//!   similarity tasks.
-//!
-//! Usage:
-//! - Create an instance with `RMinHash::new(num_perm, seed)`.
-//! - Process data items with `rminhash.update(items)`.
-//! - Obtain the signature with `rminhash.digest()`.
-//! - Estimate Jaccard similarity with `rminhash.jaccard(&other_rminhash)`.
+//! Algorithm version 2 changes R-MinHash signatures. Persisted version 1
+//! sketches and indexes must be rebuilt from their source tokens.
 
 use crate::py_input::for_each_token_hash;
-use crate::simd::dispatch::{apply_hash_batch_to_values, PermutationSoA};
+use crate::simd::dispatch::PermutationSoA;
 use crate::utils::{calculate_hash_fast, ratio_usize};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyIterator, PyList, PyTuple};
 use rand_core::{RngCore, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::sync::Arc;
 
+mod bucket;
 mod config;
 mod matrix;
 mod permutation_cache;
@@ -52,7 +36,10 @@ use config::DigestBuildConfig;
 use matrix::RhoDigestSidecar;
 pub use permutation_cache::{shared_permutations, SharedPermutations};
 
+pub const STATE_VERSION: u32 = 0x524d_4802;
+const PY_STATE_PREFIX: &[u8] = b"Rensa:RMinHash:2\0";
 const HASH_BATCH_SIZE: usize = 32;
+const MAX_HASH_BATCH_SIZE: usize = 4096;
 const DEFAULT_DOC_CHUNK_SIZE: usize = 2048;
 const MIN_DOC_CHUNK_SIZE: usize = 256;
 const MAX_DOC_CHUNK_SIZE: usize = 8192;
@@ -103,23 +90,51 @@ pub struct RMinHashDigestMatrix {
 }
 
 /// `RMinHash` implements the `MinHash` algorithm for efficient similarity estimation.
-#[derive(Serialize, Clone)]
+#[derive(Clone)]
 #[pyclass(module = "rensa", skip_from_py_object)]
 pub struct RMinHash {
   num_perm: usize,
   seed: u64,
   hash_values: Vec<u32>,
-  #[serde(skip, default)]
   permutations: Arc<[(u64, u64)]>,
-  #[serde(skip, default)]
   permutations_soa: Arc<PermutationSoA>,
 }
 
 #[derive(Deserialize)]
 struct RMinHashState {
+  #[serde(rename = "version", deserialize_with = "deserialize_state_version")]
+  _version: (),
   num_perm: usize,
   seed: u64,
   hash_values: Vec<u32>,
+}
+
+pub fn deserialize_state_version<'de, D>(
+  deserializer: D,
+) -> Result<(), D::Error>
+where
+  D: Deserializer<'de>,
+{
+  if u32::deserialize(deserializer)? != STATE_VERSION {
+    return Err(serde::de::Error::custom(
+      "unsupported RMinHash state version; rebuild sketches and indexes from their tokens",
+    ));
+  }
+  Ok(())
+}
+
+impl Serialize for RMinHash {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut state = serializer.serialize_struct("RMinHash", 4)?;
+    state.serialize_field("version", &STATE_VERSION)?;
+    state.serialize_field("num_perm", &self.num_perm)?;
+    state.serialize_field("seed", &self.seed)?;
+    state.serialize_field("hash_values", &self.hash_values)?;
+    state.end()
+  }
 }
 
 impl<'de> Deserialize<'de> for RMinHash {
@@ -128,6 +143,11 @@ impl<'de> Deserialize<'de> for RMinHash {
     D: Deserializer<'de>,
   {
     let state = RMinHashState::deserialize(deserializer)?;
+    if state.num_perm == 0 || state.hash_values.len() != state.num_perm {
+      return Err(serde::de::Error::custom(
+        "invalid RMinHash state: num_perm must equal the nonempty hash_values length",
+      ));
+    }
     Ok(Self {
       num_perm: state.num_perm,
       seed: state.seed,
@@ -304,7 +324,7 @@ impl RMinHash {
   }
 
   fn apply_hash_batch(&mut self, hash_batch: &[u64]) {
-    apply_hash_batch_to_values(
+    Self::apply_token_hashes_to_values(
       &mut self.hash_values,
       &self.permutations,
       &self.permutations_soa,
@@ -318,12 +338,7 @@ impl RMinHash {
     permutations_soa: &PermutationSoA,
     token_hashes: &[u64],
   ) {
-    apply_hash_batch_to_values(
-      hash_values,
-      permutations,
-      permutations_soa,
-      token_hashes,
-    );
+    bucket::apply(hash_values, permutations, permutations_soa, token_hashes);
   }
 
   fn apply_document_to_values(
@@ -336,8 +351,8 @@ impl RMinHash {
     hash_batch.clear();
     for_each_token_hash(document, |token_hash| {
       hash_batch.push(token_hash);
-      if hash_batch.len() == HASH_BATCH_SIZE {
-        apply_hash_batch_to_values(
+      if hash_batch.len() == MAX_HASH_BATCH_SIZE {
+        Self::apply_token_hashes_to_values(
           hash_values,
           permutations,
           permutations_soa,
@@ -348,7 +363,7 @@ impl RMinHash {
       Ok(())
     })?;
     if !hash_batch.is_empty() {
-      apply_hash_batch_to_values(
+      Self::apply_token_hashes_to_values(
         hash_values,
         permutations,
         permutations_soa,
@@ -369,7 +384,7 @@ impl RMinHash {
 
     for item in items {
       hash_batch.push(calculate_hash_fast(item.as_ref().as_bytes()));
-      if hash_batch.len() == HASH_BATCH_SIZE {
+      if hash_batch.len() == MAX_HASH_BATCH_SIZE {
         self.apply_hash_batch(&hash_batch);
         hash_batch.clear();
       }
@@ -405,5 +420,49 @@ impl RMinHash {
     _probes: usize,
   ) -> PyResult<Option<RMinHashDigestMatrix>> {
     Ok(None)
+  }
+}
+
+#[cfg(test)]
+mod serialization_tests {
+  use crate::lsh::RMinHashLSH;
+  use crate::rminhash::{RMinHash, STATE_VERSION};
+
+  #[test]
+  fn postcard_restores_sketch_updates_and_index_queries() -> pyo3::PyResult<()>
+  {
+    let mut original = RMinHash::new(128, 42)?;
+    original.update_iter(["first", "second"]);
+    let bytes = postcard::to_allocvec(&original).unwrap();
+    let mut restored: RMinHash = postcard::from_bytes(&bytes).unwrap();
+    assert_eq!(restored.digest(), original.digest());
+    original.update_iter(["third"]);
+    restored.update_iter(["third"]);
+    assert_eq!(restored.digest(), original.digest());
+
+    let mut index = RMinHashLSH::new(0.8, 128, 8)?;
+    index.insert(0, &original)?;
+    let bytes = postcard::to_allocvec(&index).unwrap();
+    let restored_index: RMinHashLSH = postcard::from_bytes(&bytes).unwrap();
+    assert_eq!(restored_index.query(&restored)?, vec![0]);
+    Ok(())
+  }
+
+  #[test]
+  fn postcard_rejects_legacy_nested_and_invalid_sketches() {
+    let legacy = (2_usize, 42_u64, vec![1_u32, 2]);
+    let bytes = postcard::to_allocvec(&legacy).unwrap();
+    assert!(postcard::from_bytes::<RMinHash>(&bytes).is_err());
+    let bytes = postcard::to_allocvec(&vec![legacy]).unwrap();
+    assert!(postcard::from_bytes::<Vec<RMinHash>>(&bytes).is_err());
+    for (version, num_perm, values) in [
+      (STATE_VERSION + 1, 1_usize, vec![0_u32]),
+      (STATE_VERSION, 0, vec![]),
+      (STATE_VERSION, 2, vec![0]),
+    ] {
+      let bytes =
+        postcard::to_allocvec(&(version, num_perm, 42_u64, values)).unwrap();
+      assert!(postcard::from_bytes::<RMinHash>(&bytes).is_err());
+    }
   }
 }

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -38,6 +38,40 @@ impl HashValue for ReadOnlyCell<u64> {
 }
 
 #[inline]
+fn for_each_mixed<H: HashValue>(
+  hashes: &[H],
+  seed: u64,
+  mut visit: impl FnMut(u64),
+) {
+  let mut chunks = hashes.chunks_exact(8);
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  if hashes.len() >= 8 {
+    if let Some(mixer) = crate::simd::dispatch::Avx512Mixer::detect() {
+      for chunk in chunks.by_ref() {
+        let mut values = std::array::from_fn(|i| chunk[i].value());
+        mixer.mix(&mut values, seed);
+        for mixed in values {
+          visit(mixed);
+        }
+      }
+      for hash in chunks.remainder() {
+        visit(splitmix64(hash.value() ^ seed));
+      }
+      return;
+    }
+  }
+  for chunk in chunks.by_ref() {
+    let values: [u64; 8] = std::array::from_fn(|i| chunk[i].value());
+    for hash in values {
+      visit(splitmix64(hash ^ seed));
+    }
+  }
+  for hash in chunks.remainder() {
+    visit(splitmix64(hash.value() ^ seed));
+  }
+}
+
+#[inline]
 #[allow(clippy::cast_possible_truncation)]
 fn bucket_index(mut mixed: u64, count: u32) -> usize {
   let threshold = count.wrapping_neg() % count;
@@ -83,8 +117,7 @@ pub(super) fn apply<H: HashValue>(
         // value and later rounds cannot improve it.
         let seed = permutations[0].1 ^ BUCKET_DOMAIN;
         let shift = 32 - count.trailing_zeros();
-        let mut update = |hash| {
-          let mixed = splitmix64(hash ^ seed);
+        for_each_mixed(remaining, seed, |mixed| {
           #[allow(clippy::cast_possible_truncation)]
           let rank = (mixed >> (32 + RANK_BITS)) as u32;
           // Minima only decrease, so this stale maximum remains an upper
@@ -100,17 +133,7 @@ pub(super) fn apply<H: HashValue>(
           if rank < *value {
             *value = rank;
           }
-        };
-        let mut chunks = remaining.chunks_exact(8);
-        for chunk in chunks.by_ref() {
-          let values: [u64; 8] = std::array::from_fn(|i| chunk[i].value());
-          for hash in values {
-            update(hash);
-          }
-        }
-        for hash in chunks.remainder() {
-          update(hash.value());
-        }
+        });
         return;
       }
       apply_unfiltered(hash_values, permutations, soa, remaining);
@@ -166,8 +189,7 @@ fn apply_unfiltered<H: HashValue>(
     if let Ok(count) = u32::try_from(len) {
       if count.is_power_of_two() {
         let shift = 32 - count.trailing_zeros();
-        let mut update = |hash, conditional| {
-          let mixed = splitmix64(hash ^ stage_seed);
+        let mut update = |mixed: u64, conditional| {
           // Lemire's product selects these bits without rejection for powers
           // of two. A u64 shift also handles one bucket (shift 32).
           #[allow(clippy::cast_possible_truncation)]
@@ -188,43 +210,23 @@ fn apply_unfiltered<H: HashValue>(
         };
         let prefix_len = hashes.len().min(len.saturating_mul(8).max(1024));
         let (initial, remaining) = hashes.split_at(prefix_len);
-        let mut chunks = initial.chunks_exact(8);
-        for chunk in chunks.by_ref() {
-          let values: [u64; 8] = std::array::from_fn(|i| chunk[i].value());
-          for hash in values {
-            update(hash, false);
-          }
-        }
-        for hash in chunks.remainder() {
-          update(hash.value(), false);
-        }
-        let mut chunks = remaining.chunks_exact(8);
-        for chunk in chunks.by_ref() {
-          let values: [u64; 8] = std::array::from_fn(|i| chunk[i].value());
-          for hash in values {
-            update(hash, true);
-          }
-        }
-        for hash in chunks.remainder() {
-          update(hash.value(), true);
-        }
+        for_each_mixed(initial, stage_seed, |mixed| update(mixed, false));
+        for_each_mixed(remaining, stage_seed, |mixed| update(mixed, true));
       } else {
-        for hash in hashes {
-          let mixed = splitmix64(hash.value() ^ stage_seed);
+        for_each_mixed(hashes, stage_seed, |mixed| {
           let bucket = bucket_index(mixed, count);
           #[allow(clippy::cast_possible_truncation)]
           let rank = prefix | (mixed >> (32 + RANK_BITS)) as u32;
           hash_values[bucket] = hash_values[bucket].min(rank);
-        }
+        });
       }
     } else {
-      for hash in hashes {
-        let mixed = splitmix64(hash.value() ^ stage_seed);
+      for_each_mixed(hashes, stage_seed, |mixed| {
         let bucket = wide_bucket_index(splitmix64(mixed), len);
         #[allow(clippy::cast_possible_truncation)]
         let rank = prefix | (mixed >> (32 + RANK_BITS)) as u32;
         hash_values[bucket] = hash_values[bucket].min(rank);
-      }
+      });
     }
     let next_prefix = (round + 1) << FRACTION_BITS;
     if !fresh_short && hash_values.iter().all(|&value| value < next_prefix) {

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -8,6 +8,7 @@ use crate::rminhash::rho::splitmix64;
 use crate::simd::dispatch::{
   apply_bucket_fallback, apply_hash_batch_to_values, PermutationSoA,
 };
+use pyo3::buffer::ReadOnlyCell;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
 const RANK_BITS: u32 = 2;
@@ -17,6 +18,24 @@ const FALLBACK: u32 = BUCKET_ROUNDS << FRACTION_BITS;
 const BUCKET_DOMAIN: u64 = 0x6a09_e667_f3bc_c909;
 const ROUND_DOMAIN: u64 = 0x3c6e_f372_fe94_f82b;
 const FALLBACK_DOMAIN: u64 = 0xbb67_ae85_84ca_a73b;
+
+pub(super) trait HashValue {
+  fn value(&self) -> u64;
+}
+
+impl HashValue for u64 {
+  #[inline]
+  fn value(&self) -> u64 {
+    *self
+  }
+}
+
+impl HashValue for ReadOnlyCell<u64> {
+  #[inline]
+  fn value(&self) -> u64 {
+    self.get()
+  }
+}
 
 #[inline]
 #[allow(clippy::cast_possible_truncation)]
@@ -45,11 +64,11 @@ fn wide_bucket_index(mut mixed: u64, count: usize) -> usize {
   }
 }
 
-pub(super) fn apply(
+pub(super) fn apply<H: HashValue>(
   hash_values: &mut [u32],
   permutations: &[(u64, u64)],
   soa: &PermutationSoA,
-  hashes: &[u64],
+  hashes: &[H],
 ) {
   let len = hash_values.len().min(permutations.len());
   if len == 0 || hashes.is_empty() {
@@ -75,8 +94,8 @@ pub(super) fn apply(
       &mut small[..hashes.len()]
     };
     let fallback_seed = permutations[0].0 ^ FALLBACK_DOMAIN;
-    for (value, &hash) in mixed.iter_mut().zip(hashes) {
-      *value = splitmix64(hash ^ fallback_seed);
+    for (value, hash) in mixed.iter_mut().zip(hashes) {
+      *value = splitmix64(hash.value() ^ fallback_seed);
     }
     apply_hash_batch_to_values(hash_values, permutations, soa, mixed);
     for value in hash_values.iter_mut() {
@@ -89,16 +108,62 @@ pub(super) fn apply(
       ^ u64::from(round).wrapping_mul(ROUND_DOMAIN);
     let prefix = round << FRACTION_BITS;
     if let Ok(count) = u32::try_from(len) {
-      for &hash in hashes {
-        let mixed = splitmix64(hash ^ stage_seed);
-        let bucket = bucket_index(mixed, count);
-        #[allow(clippy::cast_possible_truncation)]
-        let rank = prefix | (mixed >> (32 + RANK_BITS)) as u32;
-        hash_values[bucket] = hash_values[bucket].min(rank);
+      if count.is_power_of_two() {
+        let shift = 32 - count.trailing_zeros();
+        let mut update = |hash, conditional| {
+          let mixed = splitmix64(hash ^ stage_seed);
+          // Lemire's product selects these bits without rejection for powers
+          // of two. A u64 shift also handles one bucket (shift 32).
+          #[allow(clippy::cast_possible_truncation)]
+          let bucket = (u64::from(mixed as u32) >> shift) as usize;
+          #[allow(clippy::cast_possible_truncation)]
+          let rank = prefix | (mixed >> (32 + RANK_BITS)) as u32;
+          // SAFETY: count equals this slice's length and is 2^p, with p in
+          // 0..=31. The low word is < 2^32, so shifting it by 32-p yields
+          // bucket < 2^p = count, including p=0 (a u64 shift by 32).
+          let value = unsafe { hash_values.get_unchecked_mut(bucket) };
+          if conditional {
+            if rank < *value {
+              *value = rank;
+            }
+          } else {
+            *value = (*value).min(rank);
+          }
+        };
+        let prefix_len = hashes.len().min(len.saturating_mul(8).max(1024));
+        let (initial, remaining) = hashes.split_at(prefix_len);
+        let mut chunks = initial.chunks_exact(8);
+        for chunk in chunks.by_ref() {
+          let values: [u64; 8] = std::array::from_fn(|i| chunk[i].value());
+          for hash in values {
+            update(hash, false);
+          }
+        }
+        for hash in chunks.remainder() {
+          update(hash.value(), false);
+        }
+        let mut chunks = remaining.chunks_exact(8);
+        for chunk in chunks.by_ref() {
+          let values: [u64; 8] = std::array::from_fn(|i| chunk[i].value());
+          for hash in values {
+            update(hash, true);
+          }
+        }
+        for hash in chunks.remainder() {
+          update(hash.value(), true);
+        }
+      } else {
+        for hash in hashes {
+          let mixed = splitmix64(hash.value() ^ stage_seed);
+          let bucket = bucket_index(mixed, count);
+          #[allow(clippy::cast_possible_truncation)]
+          let rank = prefix | (mixed >> (32 + RANK_BITS)) as u32;
+          hash_values[bucket] = hash_values[bucket].min(rank);
+        }
       }
     } else {
-      for &hash in hashes {
-        let mixed = splitmix64(hash ^ stage_seed);
+      for hash in hashes {
+        let mixed = splitmix64(hash.value() ^ stage_seed);
         let bucket = wide_bucket_index(splitmix64(mixed), len);
         #[allow(clippy::cast_possible_truncation)]
         let rank = prefix | (mixed >> (32 + RANK_BITS)) as u32;
@@ -130,7 +195,8 @@ pub(super) fn apply(
     let capacity = len.min(512);
     let mut seen = FxHashSet::with_capacity_and_hasher(capacity, FxBuildHasher);
     heap = Vec::with_capacity(capacity);
-    for &hash in hashes {
+    for hash in hashes {
+      let hash = hash.value();
       if seen.insert(hash) {
         heap.push(splitmix64(hash ^ fallback_seed));
       }
@@ -150,8 +216,8 @@ pub(super) fn apply(
       heap = vec![0; hashes.len()];
       &mut heap
     };
-    for (value, &hash) in mixed.iter_mut().zip(hashes) {
-      *value = splitmix64(hash ^ fallback_seed);
+    for (value, hash) in mixed.iter_mut().zip(hashes) {
+      *value = splitmix64(hash.value() ^ fallback_seed);
     }
     mixed
   };
@@ -355,6 +421,55 @@ mod tests {
             "fallback deduplication changed the signature"
           );
         }
+      }
+    }
+  }
+
+  #[test]
+  fn long_rows_keep_late_improvements_across_incremental_updates() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x0042_4f55_4e44);
+    for count in [8, 128, 512] {
+      let permutations: Vec<_> = (0..count)
+        .map(|_| (rng.next_u64() | 1, rng.next_u64()))
+        .collect();
+      let soa = PermutationSoA::from_permutations(&permutations);
+      let count_u32 = u32::try_from(count).unwrap();
+      let block_len = (count * 8).max(1024);
+      let stage_seed = permutations[0].1 ^ BUCKET_DOMAIN;
+      let mut representatives = vec![None; count];
+      let mut missing = count;
+      while missing != 0 {
+        let hash = rng.next_u64();
+        let bucket = bucket_index(splitmix64(hash ^ stage_seed), count_u32);
+        if representatives[bucket].replace(hash).is_none() {
+          missing -= 1;
+        }
+      }
+      let mut hashes: Vec<_> = representatives.into_iter().flatten().collect();
+      hashes.extend((count..block_len).map(|_| rng.next_u64()));
+      let prefix_len = hashes.len();
+      let mut initial = vec![u32::MAX; count];
+      reference(&mut initial, &permutations, &hashes);
+      assert!(initial.iter().all(|&value| value < 1 << FRACTION_BITS));
+
+      hashes.extend((0..block_len * 3 + 3).map(|_| rng.next_u64()));
+      hashes.extend_from_within(..count);
+      let mut expected = vec![u32::MAX; count];
+      reference(&mut expected, &permutations, &hashes);
+      assert_ne!(expected, initial, "fixture must contain later improvements");
+
+      let mut actual = vec![u32::MAX; count];
+      apply(&mut actual, &permutations, &soa, &hashes);
+      assert_eq!(actual, expected);
+      hashes.reverse();
+      for split in [1, prefix_len - 1, prefix_len, prefix_len + 1] {
+        let mut actual = vec![u32::MAX; count];
+        apply(&mut actual, &permutations, &soa, &hashes[..split]);
+        apply(&mut actual, &permutations, &soa, &hashes[split..]);
+        assert_eq!(
+          actual, expected,
+          "chunk boundaries changed an incremental minimum"
+        );
       }
     }
   }

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -21,6 +21,15 @@ const FALLBACK_DOMAIN: u64 = 0xbb67_ae85_84ca_a73b;
 
 pub(super) trait HashValue {
   fn value(&self) -> u64;
+
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  fn mix_chunk(
+    values: &[Self; 8],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+  ) -> [u64; 8]
+  where
+    Self: Sized;
 }
 
 impl HashValue for u64 {
@@ -28,12 +37,32 @@ impl HashValue for u64 {
   fn value(&self) -> u64 {
     *self
   }
+
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  #[inline]
+  fn mix_chunk(
+    values: &[Self; 8],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+  ) -> [u64; 8] {
+    mixer.mix(values, seed)
+  }
 }
 
 impl HashValue for ReadOnlyCell<u64> {
   #[inline]
   fn value(&self) -> u64 {
     self.get()
+  }
+
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  #[inline]
+  fn mix_chunk(
+    values: &[Self; 8],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+  ) -> [u64; 8] {
+    mixer.mix_cells(values, seed)
   }
 }
 
@@ -48,10 +77,10 @@ fn for_each_mixed<H: HashValue>(
   if hashes.len() >= 8 {
     if let Some(mixer) = crate::simd::dispatch::Avx512Mixer::detect() {
       for chunk in chunks.by_ref() {
-        let mut values = std::array::from_fn(|i| chunk[i].value());
-        mixer.mix(&mut values, seed);
-        for mixed in values {
-          visit(mixed);
+        if let Some(values) = chunk.first_chunk::<8>() {
+          for mixed in H::mix_chunk(values, mixer, seed) {
+            visit(mixed);
+          }
         }
       }
       for hash in chunks.remainder() {

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -1,0 +1,331 @@
+//! Full-set sketch with three bucket rounds and per-coordinate fallback minima.
+//!
+//! Inspired by Fast Similarity Sketching (arXiv:1704.04370). The round tag is
+//! part of each stored priority, so every path computes the same coordinatewise
+//! minimum, including incremental updates across different occupancy levels.
+
+use crate::rminhash::rho::splitmix64;
+use crate::simd::dispatch::{
+  apply_bucket_fallback, apply_hash_batch_to_values, PermutationSoA,
+};
+use rustc_hash::{FxBuildHasher, FxHashSet};
+
+const RANK_BITS: u32 = 2;
+const FRACTION_BITS: u32 = 32 - RANK_BITS;
+const BUCKET_ROUNDS: u32 = (1 << RANK_BITS) - 1;
+const FALLBACK: u32 = BUCKET_ROUNDS << FRACTION_BITS;
+const BUCKET_DOMAIN: u64 = 0x6a09_e667_f3bc_c909;
+const ROUND_DOMAIN: u64 = 0x3c6e_f372_fe94_f82b;
+const FALLBACK_DOMAIN: u64 = 0xbb67_ae85_84ca_a73b;
+
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+fn bucket_index(mut mixed: u64, count: u32) -> usize {
+  let threshold = count.wrapping_neg() % count;
+  loop {
+    let product = u64::from(mixed as u32) * u64::from(count);
+    if product as u32 >= threshold {
+      return (product >> 32) as usize;
+    }
+    mixed = splitmix64(mixed);
+  }
+}
+
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+fn wide_bucket_index(mut mixed: u64, count: usize) -> usize {
+  let count = count as u64;
+  let threshold = count.wrapping_neg() % count;
+  loop {
+    let product = u128::from(mixed) * u128::from(count);
+    if product as u64 >= threshold {
+      return (product >> 64) as usize;
+    }
+    mixed = splitmix64(mixed);
+  }
+}
+
+pub(super) fn apply(
+  hash_values: &mut [u32],
+  permutations: &[(u64, u64)],
+  soa: &PermutationSoA,
+  hashes: &[u64],
+) {
+  let len = hash_values.len().min(permutations.len());
+  if len == 0 || hashes.is_empty() {
+    return;
+  }
+  let hash_values = &mut hash_values[..len];
+  for round in 0..BUCKET_ROUNDS {
+    let stage_seed = permutations[0].1
+      ^ BUCKET_DOMAIN
+      ^ u64::from(round).wrapping_mul(ROUND_DOMAIN);
+    let prefix = round << FRACTION_BITS;
+    if let Ok(count) = u32::try_from(len) {
+      for &hash in hashes {
+        let mixed = splitmix64(hash ^ stage_seed);
+        let bucket = bucket_index(mixed, count);
+        #[allow(clippy::cast_possible_truncation)]
+        let rank = prefix | (mixed >> (32 + RANK_BITS)) as u32;
+        hash_values[bucket] = hash_values[bucket].min(rank);
+      }
+    } else {
+      for &hash in hashes {
+        let mixed = splitmix64(hash ^ stage_seed);
+        let bucket = wide_bucket_index(splitmix64(mixed), len);
+        #[allow(clippy::cast_possible_truncation)]
+        let rank = prefix | (mixed >> (32 + RANK_BITS)) as u32;
+        hash_values[bucket] = hash_values[bucket].min(rank);
+      }
+    }
+    let next_prefix = (round + 1) << FRACTION_BITS;
+    if hash_values.iter().all(|&value| value < next_prefix) {
+      return;
+    }
+  }
+
+  let missing = hash_values
+    .iter()
+    .filter(|&&value| value >= FALLBACK)
+    .count();
+  if missing == 0 {
+    return;
+  }
+  let mut tiny;
+  let mut small;
+  let mut stack;
+  let mut heap;
+  let fallback_seed = permutations[0].0 ^ FALLBACK_DOMAIN;
+  let mixed = if hashes.len() / 4 > len {
+    let capacity = len.min(512);
+    let mut seen = FxHashSet::with_capacity_and_hasher(capacity, FxBuildHasher);
+    heap = Vec::with_capacity(capacity);
+    for &hash in hashes {
+      if seen.insert(hash) {
+        heap.push(splitmix64(hash ^ fallback_seed));
+      }
+    }
+    &mut heap
+  } else {
+    let mixed = if hashes.len() <= 8 {
+      tiny = [0; 8];
+      &mut tiny[..hashes.len()]
+    } else if hashes.len() <= 32 {
+      small = [0; 32];
+      &mut small[..hashes.len()]
+    } else if hashes.len() <= 128 {
+      stack = [0; 128];
+      &mut stack[..hashes.len()]
+    } else {
+      heap = vec![0; hashes.len()];
+      &mut heap
+    };
+    for (value, &hash) in mixed.iter_mut().zip(hashes) {
+      *value = splitmix64(hash ^ fallback_seed);
+    }
+    mixed
+  };
+  if missing > 3 && (hashes.len() <= 32 || missing >= len - len / 4) {
+    let mut small;
+    let mut large;
+    let mut heap;
+    let raw = if len <= 128 {
+      small = [u32::MAX; 128];
+      &mut small[..len]
+    } else if len <= 512 {
+      large = [u32::MAX; 512];
+      &mut large[..len]
+    } else {
+      heap = vec![u32::MAX; len];
+      &mut heap
+    };
+    apply_hash_batch_to_values(raw, permutations, soa, mixed);
+    for (value, &rank) in hash_values.iter_mut().zip(raw.iter()) {
+      *value = (*value).min(FALLBACK | (rank >> RANK_BITS));
+    }
+  } else {
+    apply_bucket_fallback(hash_values, permutations, mixed, RANK_BITS);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::rminhash::bucket::{
+    apply, bucket_index, BUCKET_DOMAIN, BUCKET_ROUNDS, FALLBACK,
+    FALLBACK_DOMAIN, FRACTION_BITS, RANK_BITS, ROUND_DOMAIN,
+  };
+  use crate::rminhash::rho::splitmix64;
+  use crate::simd::dispatch::PermutationSoA;
+  use rand_core::{RngCore, SeedableRng};
+  use rand_xoshiro::Xoshiro256PlusPlus;
+
+  fn reference(
+    values: &mut [u32],
+    permutations: &[(u64, u64)],
+    hashes: &[u64],
+  ) {
+    if values.is_empty() {
+      return;
+    }
+    let count = u64::try_from(values.len()).unwrap();
+    for &hash in hashes {
+      let fallback_hash =
+        splitmix64(hash ^ permutations[0].0 ^ FALLBACK_DOMAIN);
+      for (value, &(a, b)) in values.iter_mut().zip(permutations) {
+        let affine = u128::from(a) * u128::from(fallback_hash) + u128::from(b);
+        let rank = FALLBACK
+          | u32::try_from(
+            (affine >> (32 + RANK_BITS))
+              & u128::from((1_u32 << FRACTION_BITS) - 1),
+          )
+          .unwrap();
+        *value = (*value).min(rank);
+      }
+      for round in 0..BUCKET_ROUNDS {
+        let mixed = splitmix64(
+          hash
+            ^ permutations[0].1
+            ^ BUCKET_DOMAIN
+            ^ u64::from(round).wrapping_mul(ROUND_DOMAIN),
+        );
+        let mut candidate = mixed;
+        let threshold = (1_u64 << 32) % count;
+        let bucket = loop {
+          let product = (candidate & u64::from(u32::MAX)) * count;
+          if product & u64::from(u32::MAX) >= threshold {
+            break usize::try_from(product >> 32).unwrap();
+          }
+          candidate = splitmix64(candidate);
+        };
+        let rank = (round << FRACTION_BITS)
+          | u32::try_from(mixed >> (32 + RANK_BITS)).unwrap();
+        values[bucket] = values[bucket].min(rank);
+      }
+    }
+  }
+
+  #[test]
+  fn bucket_mapping_rejects_incomplete_intervals() {
+    for count in [1, 3, 8, 17, 128, 512, 0x8000_0001, u32::MAX] {
+      for mixed in [0, 1, 2, u64::MAX, 0xffff_ffff_0000_0000] {
+        let mut candidate = mixed;
+        let expected = loop {
+          let product = (candidate & u64::from(u32::MAX)) * u64::from(count);
+          if product % (1_u64 << 32) >= (1_u64 << 32) % u64::from(count) {
+            break usize::try_from(product / (1_u64 << 32)).unwrap();
+          }
+          candidate = splitmix64(candidate);
+        };
+        assert_eq!(bucket_index(mixed, count), expected);
+        assert!(expected < count as usize);
+      }
+    }
+  }
+
+  #[test]
+  fn bucket_kernel_matches_canonical_family_for_subsets_and_state() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x4255_434b);
+    let universe = [0, 1, 2, u64::MAX, 1 << 32, rng.next_u64()];
+    for count in [0, 1, 3, 8, 17, 128, 512] {
+      let permutations: Vec<_> = (0..count)
+        .map(|_| (rng.next_u64() | 1, rng.next_u64()))
+        .collect();
+      let soa = PermutationSoA::from_permutations(&permutations);
+      for subset in 0..(1 << universe.len()) {
+        let hashes: Vec<_> = universe
+          .iter()
+          .enumerate()
+          .filter_map(|(index, &hash)| {
+            ((subset >> index) & 1 == 1).then_some(hash)
+          })
+          .collect();
+        for initial in [
+          vec![u32::MAX; count],
+          (0..count).map(|_| rng.next_u32()).collect(),
+        ] {
+          let mut expected = initial.clone();
+          reference(&mut expected, &permutations, &hashes);
+          let mut actual = initial.clone();
+          apply(&mut actual, &permutations, &soa, &hashes);
+          assert_eq!(actual, expected);
+          apply(&mut actual, &permutations, &soa, &hashes);
+          assert_eq!(actual, expected, "duplicate update changed the minimum");
+
+          for split in 0..=hashes.len() {
+            let mut chunked = initial.clone();
+            apply(&mut chunked, &permutations, &soa, &hashes[..split]);
+            apply(&mut chunked, &permutations, &soa, &hashes[split..]);
+            assert_eq!(
+              chunked, expected,
+              "chunk boundary changed the signature"
+            );
+          }
+          let mut reversed = hashes.clone();
+          reversed.reverse();
+          let mut actual = initial;
+          apply(&mut actual, &permutations, &soa, &reversed);
+          assert_eq!(actual, expected, "token order changed the signature");
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn bucket_kernel_matches_canonical_family_for_dense_inputs_and_merges() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(u64::MAX);
+    for count in [1, 3, 8, 17, 128, 512] {
+      let permutations: Vec<_> = (0..count)
+        .map(|_| (rng.next_u64() | 1, rng.next_u64()))
+        .collect();
+      let soa = PermutationSoA::from_permutations(&permutations);
+      for size in [count, count * 2, count * 8] {
+        let hashes: Vec<_> = (0..size).map(|_| rng.next_u64()).collect();
+        let mut expected = vec![u32::MAX; count];
+        reference(&mut expected, &permutations, &hashes);
+        let mut actual = vec![u32::MAX; count];
+        apply(&mut actual, &permutations, &soa, &hashes);
+        assert_eq!(actual, expected);
+
+        let mut left = vec![u32::MAX; count];
+        let mut right = vec![u32::MAX; count];
+        apply(&mut left, &permutations, &soa, &hashes[..size / 2]);
+        apply(&mut right, &permutations, &soa, &hashes[size / 2..]);
+        for (value, other) in left.iter_mut().zip(right) {
+          *value = (*value).min(other);
+        }
+        assert_eq!(left, expected, "merging changed the signature");
+      }
+    }
+  }
+
+  #[test]
+  fn repeated_tokens_keep_unique_signature_across_fallback_boundaries() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x5245_5045_4154);
+    for count in [128, 129, 512] {
+      let permutations: Vec<_> = (0..count)
+        .map(|_| (rng.next_u64() | 1, rng.next_u64()))
+        .collect();
+      let soa = PermutationSoA::from_permutations(&permutations);
+      for unique in [&[0_u64][..], &[0, 1, u64::MAX][..]] {
+        let mut hashes: Vec<_> =
+          unique.iter().copied().cycle().take(8192).collect();
+        let mut expected = vec![u32::MAX; count];
+        reference(&mut expected, &permutations, unique);
+        let mut actual = vec![u32::MAX; count];
+        apply(&mut actual, &permutations, &soa, &hashes);
+        assert_eq!(actual, expected);
+
+        hashes.reverse();
+        for split in [1, count * 4, count * 4 + 4, hashes.len() - 1] {
+          let mut actual = vec![u32::MAX; count];
+          apply(&mut actual, &permutations, &soa, &hashes[..split]);
+          apply(&mut actual, &permutations, &soa, &hashes[split..]);
+          assert_eq!(
+            actual, expected,
+            "fallback deduplication changed the signature"
+          );
+        }
+      }
+    }
+  }
+}

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -142,10 +142,10 @@ fn for_each_mixed<H: HashValue>(
   seed: u64,
   mut visit: impl FnMut(u64),
 ) {
-  let mut chunks = hashes.chunks_exact(8);
   #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
   if hashes.len() >= 8 {
     if let Some(mixer) = crate::simd::dispatch::Avx512Mixer::detect() {
+      let mut chunks = hashes.chunks_exact(8);
       for chunk in chunks.by_ref() {
         if let Some(values) = chunk.first_chunk::<8>() {
           for mixed in H::mix_chunk(values, mixer, seed) {
@@ -159,6 +159,16 @@ fn for_each_mixed<H: HashValue>(
       return;
     }
   }
+  for_each_mixed_scalar(hashes, seed, &mut visit);
+}
+
+#[inline]
+fn for_each_mixed_scalar<H: HashValue>(
+  hashes: &[H],
+  seed: u64,
+  mut visit: impl FnMut(u64),
+) {
+  let mut chunks = hashes.chunks_exact(8);
   for chunk in chunks.by_ref() {
     let values: [u64; 8] = std::array::from_fn(|i| chunk[i].value());
     for hash in values {
@@ -375,7 +385,18 @@ fn apply_unfiltered<H: HashValue>(
         let prefix_len = hashes.len().min(len.saturating_mul(8).max(1024));
         let (initial, remaining) = hashes.split_at(prefix_len);
         for_each_mixed(initial, stage_seed, |mixed| update(mixed, false));
-        for_each_mixed(remaining, stage_seed, |mixed| update(mixed, true));
+        // Long conditional spans favor scalar mixing over transferring each
+        // vector batch back to scalar bucket updates. Keep dense fills and
+        // rank-filtered spans on their existing paths.
+        if cfg!(any(target_arch = "x86", target_arch = "x86_64"))
+          && remaining.len() >= 16_384
+        {
+          for_each_mixed_scalar(remaining, stage_seed, |mixed| {
+            update(mixed, true);
+          });
+        } else {
+          for_each_mixed(remaining, stage_seed, |mixed| update(mixed, true));
+        }
       } else {
         for_each_mixed(hashes, stage_seed, |mixed| {
           let bucket = bucket_index(mixed, count);
@@ -674,7 +695,10 @@ mod tests {
       reference(&mut initial, &permutations, &hashes);
       assert!(initial.iter().all(|&value| value < 1 << FRACTION_BITS));
 
-      hashes.extend((0..block_len * 3 + 3).map(|_| rng.next_u64()));
+      // The complete row crosses the scalar conditional-span threshold;
+      // incremental calls below also exercise shorter vector spans on x86.
+      hashes
+        .extend((0..(block_len * 3).max(16_384) + 3).map(|_| rng.next_u64()));
       hashes.extend_from_within(..count);
       let mut expected = vec![u32::MAX; count];
       reference(&mut expected, &permutations, &hashes);

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -71,6 +71,62 @@ pub(super) fn apply<H: HashValue>(
   hashes: &[H],
 ) {
   let len = hash_values.len().min(permutations.len());
+  if hashes.len() >= 1 << 20 && len.is_power_of_two() {
+    if let Ok(count) = u32::try_from(len) {
+      let end = len.saturating_mul(512).max(65_536).min(hashes.len());
+      let (initial, remaining) = hashes.split_at(end);
+      apply_unfiltered(hash_values, permutations, soa, initial);
+      let hash_values = &mut hash_values[..len];
+      let upper_bound = hash_values.iter().copied().max().unwrap_or(u32::MAX);
+      if upper_bound <= (1 << FRACTION_BITS) / 32 {
+        // The bound is below 2^30, so every coordinate has a round-zero
+        // value and later rounds cannot improve it.
+        let seed = permutations[0].1 ^ BUCKET_DOMAIN;
+        let shift = 32 - count.trailing_zeros();
+        let mut update = |hash| {
+          let mixed = splitmix64(hash ^ seed);
+          #[allow(clippy::cast_possible_truncation)]
+          let rank = (mixed >> (32 + RANK_BITS)) as u32;
+          // Minima only decrease, so this stale maximum remains an upper
+          // bound on every coordinate throughout the remaining input.
+          if rank >= upper_bound {
+            return;
+          }
+          #[allow(clippy::cast_possible_truncation)]
+          let bucket = (u64::from(mixed as u32) >> shift) as usize;
+          // SAFETY: count is this slice's power-of-two length, 2^p. Shifting
+          // a 32-bit word by 32-p produces an index strictly below count.
+          let value = unsafe { hash_values.get_unchecked_mut(bucket) };
+          if rank < *value {
+            *value = rank;
+          }
+        };
+        let mut chunks = remaining.chunks_exact(8);
+        for chunk in chunks.by_ref() {
+          let values: [u64; 8] = std::array::from_fn(|i| chunk[i].value());
+          for hash in values {
+            update(hash);
+          }
+        }
+        for hash in chunks.remainder() {
+          update(hash.value());
+        }
+        return;
+      }
+      apply_unfiltered(hash_values, permutations, soa, remaining);
+      return;
+    }
+  }
+  apply_unfiltered(hash_values, permutations, soa, hashes);
+}
+
+fn apply_unfiltered<H: HashValue>(
+  hash_values: &mut [u32],
+  permutations: &[(u64, u64)],
+  soa: &PermutationSoA,
+  hashes: &[H],
+) {
+  let len = hash_values.len().min(permutations.len());
   if len == 0 || hashes.is_empty() {
     return;
   }
@@ -247,8 +303,8 @@ pub(super) fn apply<H: HashValue>(
 #[cfg(test)]
 mod tests {
   use crate::rminhash::bucket::{
-    apply, bucket_index, BUCKET_DOMAIN, BUCKET_ROUNDS, FALLBACK,
-    FALLBACK_DOMAIN, FRACTION_BITS, RANK_BITS, ROUND_DOMAIN,
+    apply, apply_unfiltered, bucket_index, BUCKET_DOMAIN, BUCKET_ROUNDS,
+    FALLBACK, FALLBACK_DOMAIN, FRACTION_BITS, RANK_BITS, ROUND_DOMAIN,
   };
   use crate::rminhash::rho::splitmix64;
   use crate::simd::dispatch::PermutationSoA;
@@ -470,6 +526,61 @@ mod tests {
           actual, expected,
           "chunk boundaries changed an incremental minimum"
         );
+      }
+    }
+  }
+
+  #[test]
+  fn very_late_rank_filter_preserves_updates_and_repeated_rows() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x4c41_5445);
+    for count in [128, 512] {
+      let permutations: Vec<_> = (0..count)
+        .map(|_| (rng.next_u64() | 1, rng.next_u64()))
+        .collect();
+      let soa = PermutationSoA::from_permutations(&permutations);
+      let count_u32 = u32::try_from(count).unwrap();
+      let end = (count * 512).max(65_536);
+      for enabled in [true, false] {
+        let base = if enabled {
+          (0..end).map(|_| rng.next_u64()).collect::<Vec<_>>()
+        } else {
+          let mut representatives = vec![None; count];
+          let mut missing = count;
+          while missing != 0 {
+            let hash = rng.next_u64();
+            let mixed = splitmix64(hash ^ permutations[0].1 ^ BUCKET_DOMAIN);
+            if mixed >> (32 + RANK_BITS) < (1 << FRACTION_BITS) / 2 {
+              continue;
+            }
+            let bucket = bucket_index(mixed, count_u32);
+            if representatives[bucket].replace(hash).is_none() {
+              missing -= 1;
+            }
+          }
+          representatives.into_iter().flatten().collect()
+        };
+        let mut expected = vec![u32::MAX; count];
+        apply_unfiltered(&mut expected, &permutations, &soa, &base);
+        let initial = expected.clone();
+        assert_eq!(
+          expected.iter().copied().max().unwrap() <= (1 << FRACTION_BITS) / 32,
+          enabled
+        );
+        let late: Vec<_> = (0..4099).map(|_| rng.next_u64()).collect();
+        reference(&mut expected, &permutations, &late);
+        assert_ne!(expected, initial, "fixture needs a late improvement");
+        let mut hashes: Vec<_> =
+          base.iter().copied().cycle().take(1 << 20).collect();
+        hashes.extend_from_slice(&late);
+        let mut actual = vec![u32::MAX; count];
+        apply(&mut actual, &permutations, &soa, &hashes);
+        assert_eq!(actual, expected);
+        hashes.reverse();
+        let mut actual = vec![u32::MAX; count];
+        for chunk in hashes.chunks(end - 1) {
+          apply(&mut actual, &permutations, &soa, chunk);
+        }
+        assert_eq!(actual, expected);
       }
     }
   }

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -31,7 +31,7 @@ pub(super) trait HashValue {
   where
     Self: Sized;
 
-  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  #[cfg(target_arch = "x86")]
   fn mix_chunk_below(
     values: &[Self; 8],
     mixer: crate::simd::dispatch::Avx512Mixer,
@@ -39,6 +39,17 @@ pub(super) trait HashValue {
     bound: u32,
     output: &mut [u64; 8],
   ) -> u8
+  where
+    Self: Sized;
+
+  #[cfg(target_arch = "x86_64")]
+  fn apply_below(
+    values: &[Self],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+    bound: u32,
+    hash_values: &mut [u32],
+  ) -> usize
   where
     Self: Sized;
 }
@@ -59,7 +70,7 @@ impl HashValue for u64 {
     mixer.mix(values, seed)
   }
 
-  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  #[cfg(target_arch = "x86")]
   #[inline]
   fn mix_chunk_below(
     values: &[Self; 8],
@@ -69,6 +80,18 @@ impl HashValue for u64 {
     output: &mut [u64; 8],
   ) -> u8 {
     mixer.mix_below::<{ 32 + RANK_BITS }>(values, seed, bound, output)
+  }
+
+  #[cfg(target_arch = "x86_64")]
+  #[inline]
+  fn apply_below(
+    values: &[Self],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+    bound: u32,
+    hash_values: &mut [u32],
+  ) -> usize {
+    mixer.apply_below(values, seed, bound, hash_values)
   }
 }
 
@@ -88,7 +111,7 @@ impl HashValue for ReadOnlyCell<u64> {
     mixer.mix_cells(values, seed)
   }
 
-  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  #[cfg(target_arch = "x86")]
   #[inline]
   fn mix_chunk_below(
     values: &[Self; 8],
@@ -98,6 +121,18 @@ impl HashValue for ReadOnlyCell<u64> {
     output: &mut [u64; 8],
   ) -> u8 {
     mixer.mix_cells_below::<{ 32 + RANK_BITS }>(values, seed, bound, output)
+  }
+
+  #[cfg(target_arch = "x86_64")]
+  #[inline]
+  fn apply_below(
+    values: &[Self],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+    bound: u32,
+    hash_values: &mut [u32],
+  ) -> usize {
+    mixer.apply_cells_below(values, seed, bound, hash_values)
   }
 }
 
@@ -142,7 +177,7 @@ fn for_each_mixed_below<H: HashValue>(
   bound: u32,
   mut visit: impl FnMut(u64),
 ) {
-  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  #[cfg(target_arch = "x86")]
   if hashes.len() >= 8 {
     if let Some(mixer) = crate::simd::dispatch::Avx512Mixer::detect() {
       let mut chunks = hashes.chunks_exact(8);
@@ -243,6 +278,14 @@ pub(super) fn apply<H: HashValue>(
         let shift = 32 - count.trailing_zeros();
         // Minima only decrease, so this stale maximum remains an upper bound
         // on every coordinate throughout the remaining input.
+        #[cfg(target_arch = "x86_64")]
+        let remaining = {
+          let consumed =
+            crate::simd::dispatch::Avx512Mixer::detect().map_or(0, |mixer| {
+              H::apply_below(remaining, mixer, seed, upper_bound, hash_values)
+            });
+          &remaining[consumed..]
+        };
         for_each_mixed_below(remaining, seed, upper_bound, |mixed| {
           #[allow(clippy::cast_possible_truncation)]
           let rank = (mixed >> (32 + RANK_BITS)) as u32;

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -253,7 +253,7 @@ pub(super) fn apply<H: HashValue>(
   let early_filter = hashes.len() >= 65_536
     && hashes.len() < 1 << 20
     && len.is_power_of_two()
-    && hashes.len() / len >= 128
+    && hashes.len() / len >= 256
     && crate::simd::dispatch::Avx512Mixer::detect().is_some();
   if (hashes.len() >= 1 << 20 || early_filter) && len.is_power_of_two() {
     if let Ok(count) = u32::try_from(len) {
@@ -733,8 +733,12 @@ mod tests {
         let late: Vec<_> = (0..4099).map(|_| rng.next_u64()).collect();
         reference(&mut expected, &permutations, &late);
         assert_ne!(expected, initial, "fixture needs a late improvement");
-        let mut hashes: Vec<_> =
-          base.iter().copied().cycle().take(65_536).collect();
+        let mut hashes: Vec<_> = base
+          .iter()
+          .copied()
+          .cycle()
+          .take(65_536.max(count * 256))
+          .collect();
         hashes.extend_from_slice(&late);
         let prefix = hashes.len() / 2;
         let mut prefix_values = vec![u32::MAX; count];

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -37,7 +37,8 @@ pub(super) trait HashValue {
     mixer: crate::simd::dispatch::Avx512Mixer,
     seed: u64,
     bound: u32,
-  ) -> Option<([u64; 8], u8)>
+    output: &mut [u64; 8],
+  ) -> u8
   where
     Self: Sized;
 }
@@ -65,8 +66,9 @@ impl HashValue for u64 {
     mixer: crate::simd::dispatch::Avx512Mixer,
     seed: u64,
     bound: u32,
-  ) -> Option<([u64; 8], u8)> {
-    mixer.mix_below::<{ 32 + RANK_BITS }>(values, seed, bound)
+    output: &mut [u64; 8],
+  ) -> u8 {
+    mixer.mix_below::<{ 32 + RANK_BITS }>(values, seed, bound, output)
   }
 }
 
@@ -93,8 +95,9 @@ impl HashValue for ReadOnlyCell<u64> {
     mixer: crate::simd::dispatch::Avx512Mixer,
     seed: u64,
     bound: u32,
-  ) -> Option<([u64; 8], u8)> {
-    mixer.mix_cells_below::<{ 32 + RANK_BITS }>(values, seed, bound)
+    output: &mut [u64; 8],
+  ) -> u8 {
+    mixer.mix_cells_below::<{ 32 + RANK_BITS }>(values, seed, bound, output)
   }
 }
 
@@ -143,16 +146,15 @@ fn for_each_mixed_below<H: HashValue>(
   if hashes.len() >= 8 {
     if let Some(mixer) = crate::simd::dispatch::Avx512Mixer::detect() {
       let mut chunks = hashes.chunks_exact(8);
+      let mut mixed = [0; 8];
       for chunk in chunks.by_ref() {
         if let Some(values) = chunk.first_chunk::<8>() {
-          if let Some((mixed, mut mask)) =
-            H::mix_chunk_below(values, mixer, seed, bound)
-          {
-            while mask != 0 {
-              let lane = mask.trailing_zeros() as usize;
-              visit(mixed[lane]);
-              mask &= mask - 1;
-            }
+          let mut mask =
+            H::mix_chunk_below(values, mixer, seed, bound, &mut mixed);
+          while mask != 0 {
+            let lane = mask.trailing_zeros() as usize;
+            visit(mixed[lane]);
+            mask &= mask - 1;
           }
         }
       }

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -30,6 +30,16 @@ pub(super) trait HashValue {
   ) -> [u64; 8]
   where
     Self: Sized;
+
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  fn mix_chunk_below(
+    values: &[Self; 8],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+    bound: u32,
+  ) -> Option<([u64; 8], u8)>
+  where
+    Self: Sized;
 }
 
 impl HashValue for u64 {
@@ -47,6 +57,17 @@ impl HashValue for u64 {
   ) -> [u64; 8] {
     mixer.mix(values, seed)
   }
+
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  #[inline]
+  fn mix_chunk_below(
+    values: &[Self; 8],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+    bound: u32,
+  ) -> Option<([u64; 8], u8)> {
+    mixer.mix_below::<{ 32 + RANK_BITS }>(values, seed, bound)
+  }
 }
 
 impl HashValue for ReadOnlyCell<u64> {
@@ -63,6 +84,17 @@ impl HashValue for ReadOnlyCell<u64> {
     seed: u64,
   ) -> [u64; 8] {
     mixer.mix_cells(values, seed)
+  }
+
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  #[inline]
+  fn mix_chunk_below(
+    values: &[Self; 8],
+    mixer: crate::simd::dispatch::Avx512Mixer,
+    seed: u64,
+    bound: u32,
+  ) -> Option<([u64; 8], u8)> {
+    mixer.mix_cells_below::<{ 32 + RANK_BITS }>(values, seed, bound)
   }
 }
 
@@ -101,6 +133,50 @@ fn for_each_mixed<H: HashValue>(
 }
 
 #[inline]
+fn for_each_mixed_below<H: HashValue>(
+  hashes: &[H],
+  seed: u64,
+  bound: u32,
+  mut visit: impl FnMut(u64),
+) {
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  if hashes.len() >= 8 {
+    if let Some(mixer) = crate::simd::dispatch::Avx512Mixer::detect() {
+      let mut chunks = hashes.chunks_exact(8);
+      for chunk in chunks.by_ref() {
+        if let Some(values) = chunk.first_chunk::<8>() {
+          if let Some((mixed, mut mask)) =
+            H::mix_chunk_below(values, mixer, seed, bound)
+          {
+            while mask != 0 {
+              let lane = mask.trailing_zeros() as usize;
+              visit(mixed[lane]);
+              mask &= mask - 1;
+            }
+          }
+        }
+      }
+      for hash in chunks.remainder() {
+        let mixed = splitmix64(hash.value() ^ seed);
+        #[allow(clippy::cast_possible_truncation)]
+        let rank = (mixed >> (32 + RANK_BITS)) as u32;
+        if rank < bound {
+          visit(mixed);
+        }
+      }
+      return;
+    }
+  }
+  for_each_mixed(hashes, seed, |mixed| {
+    #[allow(clippy::cast_possible_truncation)]
+    let rank = (mixed >> (32 + RANK_BITS)) as u32;
+    if rank < bound {
+      visit(mixed);
+    }
+  });
+}
+
+#[inline]
 #[allow(clippy::cast_possible_truncation)]
 fn bucket_index(mut mixed: u64, count: u32) -> usize {
   let threshold = count.wrapping_neg() % count;
@@ -134,26 +210,40 @@ pub(super) fn apply<H: HashValue>(
   hashes: &[H],
 ) {
   let len = hash_values.len().min(permutations.len());
-  if hashes.len() >= 1 << 20 && len.is_power_of_two() {
+  #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+  let early_filter = false;
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  let early_filter = hashes.len() >= 65_536
+    && hashes.len() < 1 << 20
+    && len.is_power_of_two()
+    && hashes.len() / len >= 128
+    && crate::simd::dispatch::Avx512Mixer::detect().is_some();
+  if (hashes.len() >= 1 << 20 || early_filter) && len.is_power_of_two() {
     if let Ok(count) = u32::try_from(len) {
-      let end = len.saturating_mul(512).max(65_536).min(hashes.len());
+      let (end, maximum_bound) = if early_filter {
+        // Vector rejection makes a less selective bound useful, but require
+        // enough tokens per coordinate before splitting the bucket passes.
+        (hashes.len() / 2, (1 << FRACTION_BITS) / 8)
+      } else {
+        (
+          len.saturating_mul(512).max(65_536).min(hashes.len()),
+          (1 << FRACTION_BITS) / 32,
+        )
+      };
       let (initial, remaining) = hashes.split_at(end);
       apply_unfiltered(hash_values, permutations, soa, initial);
       let hash_values = &mut hash_values[..len];
       let upper_bound = hash_values.iter().copied().max().unwrap_or(u32::MAX);
-      if upper_bound <= (1 << FRACTION_BITS) / 32 {
+      if upper_bound <= maximum_bound {
         // The bound is below 2^30, so every coordinate has a round-zero
         // value and later rounds cannot improve it.
         let seed = permutations[0].1 ^ BUCKET_DOMAIN;
         let shift = 32 - count.trailing_zeros();
-        for_each_mixed(remaining, seed, |mixed| {
+        // Minima only decrease, so this stale maximum remains an upper bound
+        // on every coordinate throughout the remaining input.
+        for_each_mixed_below(remaining, seed, upper_bound, |mixed| {
           #[allow(clippy::cast_possible_truncation)]
           let rank = (mixed >> (32 + RANK_BITS)) as u32;
-          // Minima only decrease, so this stale maximum remains an upper
-          // bound on every coordinate throughout the remaining input.
-          if rank >= upper_bound {
-            return;
-          }
           #[allow(clippy::cast_possible_truncation)]
           let bucket = (u64::from(mixed as u32) >> shift) as usize;
           // SAFETY: count is this slice's power-of-two length, 2^p. Shifting
@@ -557,6 +647,72 @@ mod tests {
           actual, expected,
           "chunk boundaries changed an incremental minimum"
         );
+      }
+    }
+  }
+
+  #[test]
+  fn earlier_vector_filter_preserves_repeated_rows_and_late_improvements() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x0045_4152_4c59);
+    for count in [128, 512] {
+      let permutations: Vec<_> = (0..count)
+        .map(|_| (rng.next_u64() | 1, rng.next_u64()))
+        .collect();
+      let soa = PermutationSoA::from_permutations(&permutations);
+      let count_u32 = u32::try_from(count).unwrap();
+      for enabled in [true, false] {
+        let mut representatives = vec![None; count];
+        let mut missing = count;
+        while missing != 0 {
+          let hash = rng.next_u64();
+          let mixed = splitmix64(hash ^ permutations[0].1 ^ BUCKET_DOMAIN);
+          let rank = mixed >> (32 + RANK_BITS);
+          if (enabled && rank >= (1 << FRACTION_BITS) / 16)
+            || (!enabled && rank < (1 << FRACTION_BITS) / 2)
+          {
+            continue;
+          }
+          let bucket = bucket_index(mixed, count_u32);
+          if representatives[bucket].replace(hash).is_none() {
+            missing -= 1;
+          }
+        }
+        let base: Vec<_> = representatives.into_iter().flatten().collect();
+        let mut expected = vec![u32::MAX; count];
+        reference(&mut expected, &permutations, &base);
+        assert_eq!(
+          expected.iter().copied().max().unwrap() <= (1 << FRACTION_BITS) / 8,
+          enabled
+        );
+        let initial = expected.clone();
+        let late: Vec<_> = (0..4099).map(|_| rng.next_u64()).collect();
+        reference(&mut expected, &permutations, &late);
+        assert_ne!(expected, initial, "fixture needs a late improvement");
+        let mut hashes: Vec<_> =
+          base.iter().copied().cycle().take(65_536).collect();
+        hashes.extend_from_slice(&late);
+        let prefix = hashes.len() / 2;
+        let mut prefix_values = vec![u32::MAX; count];
+        apply_unfiltered(
+          &mut prefix_values,
+          &permutations,
+          &soa,
+          &hashes[..prefix],
+        );
+        assert_eq!(prefix_values, initial);
+        let mut actual = vec![u32::MAX; count];
+        apply(&mut actual, &permutations, &soa, &hashes);
+        assert_eq!(actual, expected);
+        for split in [prefix - 1, prefix + 1] {
+          let mut actual = vec![u32::MAX; count];
+          apply(&mut actual, &permutations, &soa, &hashes[..split]);
+          apply(&mut actual, &permutations, &soa, &hashes[split..]);
+          assert_eq!(actual, expected);
+        }
+        hashes.reverse();
+        let mut actual = vec![u32::MAX; count];
+        apply(&mut actual, &permutations, &soa, &hashes);
+        assert_eq!(actual, expected);
       }
     }
   }

--- a/src/rminhash/bucket.rs
+++ b/src/rminhash/bucket.rs
@@ -56,6 +56,33 @@ pub(super) fn apply(
     return;
   }
   let hash_values = &mut hash_values[..len];
+  let fresh_short = hashes.len() <= 32
+    && len >= 128
+    && hash_values[0] == u32::MAX
+    && hash_values
+      .iter()
+      .fold(u32::MAX, |combined, &value| combined & value)
+      == u32::MAX;
+  // Three rounds cannot fill these rows, so write their fallback in place.
+  if fresh_short {
+    let mut tiny;
+    let mut small;
+    let mixed = if hashes.len() <= 8 {
+      tiny = [0; 8];
+      &mut tiny[..hashes.len()]
+    } else {
+      small = [0; 32];
+      &mut small[..hashes.len()]
+    };
+    let fallback_seed = permutations[0].0 ^ FALLBACK_DOMAIN;
+    for (value, &hash) in mixed.iter_mut().zip(hashes) {
+      *value = splitmix64(hash ^ fallback_seed);
+    }
+    apply_hash_batch_to_values(hash_values, permutations, soa, mixed);
+    for value in hash_values.iter_mut() {
+      *value = FALLBACK | (*value >> RANK_BITS);
+    }
+  }
   for round in 0..BUCKET_ROUNDS {
     let stage_seed = permutations[0].1
       ^ BUCKET_DOMAIN
@@ -79,9 +106,12 @@ pub(super) fn apply(
       }
     }
     let next_prefix = (round + 1) << FRACTION_BITS;
-    if hash_values.iter().all(|&value| value < next_prefix) {
+    if !fresh_short && hash_values.iter().all(|&value| value < next_prefix) {
       return;
     }
+  }
+  if fresh_short {
+    return;
   }
 
   let missing = hash_values
@@ -278,7 +308,7 @@ mod tests {
         .map(|_| (rng.next_u64() | 1, rng.next_u64()))
         .collect();
       let soa = PermutationSoA::from_permutations(&permutations);
-      for size in [count, count * 2, count * 8] {
+      for size in [31, 32, 33, count, count * 2, count * 8] {
         let hashes: Vec<_> = (0..size).map(|_| rng.next_u64()).collect();
         let mut expected = vec![u32::MAX; count];
         reference(&mut expected, &permutations, &hashes);

--- a/src/rminhash/matrix.rs
+++ b/src/rminhash/matrix.rs
@@ -76,3 +76,28 @@ impl crate::rminhash::RMinHashDigestMatrix {
     sidecar.sparse_verify_signatures.get(start..end)
   }
 }
+
+#[cfg(test)]
+impl crate::rminhash::RMinHashDigestMatrix {
+  pub(crate) fn test_matrix(
+    num_perm: usize,
+    data: Vec<u32>,
+    signatures: Vec<u32>,
+    active: Vec<u8>,
+  ) -> Self {
+    let rows = data.len() / num_perm;
+    Self {
+      num_perm,
+      rows,
+      data,
+      rho_sidecar: Some(RhoDigestSidecar {
+        non_empty_counts: vec![1; rows],
+        source_token_counts: vec![1; rows],
+        sparse_occupancy_threshold: 2,
+        sparse_verify_perm: signatures.len() / rows,
+        sparse_verify_signatures: signatures,
+        sparse_verify_active: active,
+      }),
+    }
+  }
+}

--- a/src/rminhash/pipeline.rs
+++ b/src/rminhash/pipeline.rs
@@ -421,6 +421,12 @@ impl RMinHash {
         }
       }
 
+      if chunk_row_start + token_hash_ranges.len() != rows {
+        return Err(PyValueError::new_err(
+          "document list changed size during hashing",
+        ));
+      }
+
       if !token_hash_ranges.is_empty() {
         let flat = std::mem::take(&mut token_hashes_chunk);
         let ranges = std::mem::take(&mut token_hash_ranges);
@@ -507,6 +513,14 @@ impl RMinHash {
         token_hashes_chunk = Vec::with_capacity(flat_capacity);
         token_hash_ranges = Vec::with_capacity(ranges_capacity);
       }
+    }
+
+    if extraction_error.is_none()
+      && chunk_row_start + token_hash_ranges.len() != rows
+    {
+      extraction_error = Some(PyValueError::new_err(
+        "document list changed size during hashing",
+      ));
     }
 
     if extraction_error.is_none() && !token_hash_ranges.is_empty() {

--- a/src/rminhash/pipeline.rs
+++ b/src/rminhash/pipeline.rs
@@ -131,9 +131,7 @@ impl RMinHash {
     }
 
     let flat = std::mem::take(token_hashes_chunk);
-    let flat_capacity = flat.capacity();
     let ranges = std::mem::take(token_hash_ranges);
-    let ranges_capacity = ranges.capacity();
     let rows = ranges.len();
     let matrix_start = matrix_data.len();
     matrix_data.resize(matrix_start + rows * context.num_perm, u32::MAX);
@@ -157,8 +155,10 @@ impl RMinHash {
       });
     });
 
-    *token_hashes_chunk = Vec::with_capacity(flat_capacity);
-    *token_hash_ranges = Vec::with_capacity(ranges_capacity);
+    *token_hashes_chunk = job.flat;
+    token_hashes_chunk.clear();
+    *token_hash_ranges = job.ranges;
+    token_hash_ranges.clear();
   }
 
   pub(in crate::rminhash) fn build_token_hash_rows(
@@ -396,9 +396,7 @@ impl RMinHash {
 
         if token_hash_ranges.len() == config.doc_chunk_size {
           let flat = std::mem::take(&mut token_hashes_chunk);
-          let flat_capacity = flat.capacity();
           let ranges = std::mem::take(&mut token_hash_ranges);
-          let ranges_capacity = ranges.capacity();
           let row_count = ranges.len();
           let output_start = chunk_row_start * num_perm;
           let job = DigestChunkJob {
@@ -416,8 +414,10 @@ impl RMinHash {
             permutation_cache.as_mut(),
           );
           chunk_row_start += row_count;
-          token_hashes_chunk = Vec::with_capacity(flat_capacity);
-          token_hash_ranges = Vec::with_capacity(ranges_capacity);
+          token_hashes_chunk = job.flat;
+          token_hashes_chunk.clear();
+          token_hash_ranges = job.ranges;
+          token_hash_ranges.clear();
         }
       }
 

--- a/src/rminhash/pipeline.rs
+++ b/src/rminhash/pipeline.rs
@@ -1,4 +1,7 @@
-use crate::py_input::extend_prehashed_token_values_from_document;
+use crate::py_input::{
+  buffer_has_native_byte_order, extend_prehashed_token_values_from_document,
+  extend_prehashed_token_values_from_iterable, PREHASHED_TOKEN_TYPE_ERROR,
+};
 use crate::rminhash::permutation_cache::AdaptivePermutationCache;
 use crate::rminhash::send_ptr::SendPtr;
 use crate::rminhash::{
@@ -7,12 +10,14 @@ use crate::rminhash::{
 };
 use crate::simd::dispatch::PermutationSoA;
 use pyo3::buffer::{Element, PyBuffer};
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyIterator, PyList, PyTuple};
 use rayon::prelude::*;
 use std::sync::mpsc;
 use std::thread;
+
+const MIN_FLAT_BUFFER_HASHES: usize = 65_536;
 
 fn new_permutation_cache(
   config: DigestBuildConfig,
@@ -186,6 +191,73 @@ impl RMinHash {
     Ok(values)
   }
 
+  pub(in crate::rminhash) fn build_digest_matrix_from_flat_python_hashes(
+    token_hashes: &Bound<'_, PyAny>,
+    row_offsets: &Bound<'_, PyAny>,
+    num_perm: usize,
+    seed: u64,
+  ) -> PyResult<RMinHashDigestMatrix> {
+    let offsets = Self::parse_row_offsets(row_offsets)?;
+    let values = if let Ok(buffer) = PyBuffer::<u64>::get(token_hashes) {
+      if !buffer.is_c_contiguous() || !buffer_has_native_byte_order(&buffer) {
+        return Err(PyTypeError::new_err(PREHASHED_TOKEN_TYPE_ERROR));
+      }
+      if buffer.item_count() >= MIN_FLAT_BUFFER_HASHES
+        && rayon::current_num_threads() == 1
+        && DigestBuildConfig::from_env().max_perm_cache_hashes == 0
+      {
+        return Self::build_digest_matrix_from_flat_buffer(
+          token_hashes.py(),
+          &buffer,
+          &offsets,
+          num_perm,
+          seed,
+        );
+      }
+      buffer.to_vec(token_hashes.py())?
+    } else {
+      let mut values = Vec::new();
+      extend_prehashed_token_values_from_iterable(token_hashes, &mut values)?;
+      values
+    };
+    Self::build_digest_matrix_from_flat_token_hashes(
+      &values, &offsets, num_perm, seed,
+    )
+  }
+
+  fn build_digest_matrix_from_flat_buffer(
+    py: Python<'_>,
+    buffer: &PyBuffer<u64>,
+    offsets: &[usize],
+    num_perm: usize,
+    seed: u64,
+  ) -> PyResult<RMinHashDigestMatrix> {
+    Self::validate_flat_row_offsets(offsets, buffer.item_count())?;
+    let rows = offsets.len() - 1;
+    let mut data = vec![u32::MAX; checked_matrix_len(rows, num_perm)?];
+    let shared = crate::rminhash::shared_permutations(num_perm, seed);
+    let values = buffer
+      .as_slice(py)
+      .ok_or_else(|| PyTypeError::new_err(PREHASHED_TOKEN_TYPE_ERROR))?;
+    // Keep the GIL and buffer alive throughout traversal. ReadOnlyCell copies
+    // each value without assuming readonly views have no writable aliases.
+    for (row, bounds) in data.chunks_exact_mut(num_perm).zip(offsets.windows(2))
+    {
+      crate::rminhash::bucket::apply(
+        row,
+        &shared.pairs,
+        &shared.soa,
+        &values[bounds[0]..bounds[1]],
+      );
+    }
+    Ok(RMinHashDigestMatrix {
+      num_perm,
+      rows,
+      data,
+      rho_sidecar: None,
+    })
+  }
+
   fn extract_row_offset(item: &Bound<'_, PyAny>) -> PyResult<usize> {
     let value = item
       .extract::<u64>()
@@ -205,7 +277,7 @@ impl RMinHash {
     let Ok(buffer) = PyBuffer::<T>::get(values) else {
       return Ok(false);
     };
-    if !buffer.is_c_contiguous() {
+    if !buffer.is_c_contiguous() || !buffer_has_native_byte_order(&buffer) {
       return Err(PyValueError::new_err(FLAT_ROW_OFFSET_TYPE_ERROR));
     }
     let slice = unsafe {

--- a/src/rminhash/py.rs
+++ b/src/rminhash/py.rs
@@ -5,7 +5,7 @@ use crate::py_input::{
 };
 use crate::rminhash::{
   RMinHash, RMinHashDigestMatrix, ReduceResult, DEFAULT_RHO_PROBES,
-  HASH_BATCH_SIZE,
+  HASH_BATCH_SIZE, PY_STATE_PREFIX,
 };
 use crate::utils::ratio_usize;
 use pyo3::exceptions::PyValueError;
@@ -89,6 +89,10 @@ impl RMinHashDigestMatrix {
 
 #[pymethods]
 impl RMinHash {
+  /// Signature algorithm version; signatures from different versions are incompatible.
+  #[classattr]
+  const ALGORITHM_VERSION: u32 = 2;
+
   /// Creates a new `RMinHash` instance.
   ///
   /// # Arguments
@@ -423,12 +427,16 @@ impl RMinHash {
   }
 
   fn __setstate__(&mut self, state: &Bound<'_, PyBytes>) -> PyResult<()> {
-    let decoded: Self =
-      postcard::from_bytes(state.as_bytes()).map_err(|err| {
-        PyValueError::new_err(format!(
-          "failed to deserialize RMinHash state: {err}"
-        ))
-      })?;
+    let payload = state.as_bytes().strip_prefix(PY_STATE_PREFIX).ok_or_else(|| {
+      PyValueError::new_err(
+        "unsupported RMinHash state version; rebuild the sketch from its tokens",
+      )
+    })?;
+    let decoded: Self = postcard::from_bytes(payload).map_err(|err| {
+      PyValueError::new_err(format!(
+        "failed to deserialize RMinHash state: {err}"
+      ))
+    })?;
     decoded.validate_state()?;
     *self = decoded;
     Ok(())
@@ -438,11 +446,12 @@ impl RMinHash {
     &self,
     py: Python<'py>,
   ) -> PyResult<Bound<'py, PyBytes>> {
-    let encoded = postcard::to_allocvec(self).map_err(|err| {
-      PyValueError::new_err(format!(
-        "failed to serialize RMinHash state: {err}"
-      ))
-    })?;
+    let encoded =
+      postcard::to_extend(self, PY_STATE_PREFIX.to_vec()).map_err(|err| {
+        PyValueError::new_err(format!(
+          "failed to serialize RMinHash state: {err}"
+        ))
+      })?;
     Ok(PyBytes::new(py, &encoded))
   }
 

--- a/src/rminhash/py.rs
+++ b/src/rminhash/py.rs
@@ -298,6 +298,9 @@ impl RMinHash {
 
   /// Computes `RMinHash` digests in a compact row-major matrix from one flat
   /// token-hash buffer and row offsets.
+  /// Row offsets are snapshotted before acquiring or copying token values.
+  /// Large buffers in single-thread mode are read directly while retaining
+  /// the GIL, including when the input view is readonly.
   ///
   /// # Errors
   ///
@@ -313,11 +316,9 @@ impl RMinHash {
     seed: u64,
   ) -> PyResult<RMinHashDigestMatrix> {
     Self::validate_num_perm(num_perm)?;
-    let flat_hashes = Self::parse_flat_token_hashes(token_hashes)?;
-    let offsets = Self::parse_row_offsets(row_offsets)?;
-    Self::build_digest_matrix_from_flat_token_hashes(
-      &flat_hashes,
-      &offsets,
+    Self::build_digest_matrix_from_flat_python_hashes(
+      token_hashes,
+      row_offsets,
       num_perm,
       seed,
     )

--- a/src/rminhash/rho.rs
+++ b/src/rminhash/rho.rs
@@ -167,9 +167,7 @@ fn rho_sparse_verify_perm(num_perm: usize) -> usize {
 fn rho_adaptive_probes_enabled() -> bool {
   static ENABLED: OnceLock<bool> = OnceLock::new();
   *ENABLED.get_or_init(|| {
-    std::env::var("RENSA_RHO_ADAPTIVE_PROBES")
-      .ok()
-      .is_some_and(|value| value != "0")
+    std::env::var("RENSA_RHO_ADAPTIVE_PROBES").is_ok_and(|value| value != "0")
   })
 }
 
@@ -209,9 +207,7 @@ pub(super) fn effective_rho_probes(
 fn rho_densify_enabled() -> bool {
   static ENABLED: OnceLock<bool> = OnceLock::new();
   *ENABLED.get_or_init(|| {
-    std::env::var("RENSA_RHO_DENSIFY")
-      .ok()
-      .is_some_and(|value| value != "0")
+    std::env::var("RENSA_RHO_DENSIFY").is_ok_and(|value| value != "0")
   })
 }
 

--- a/src/rminhash/rho.rs
+++ b/src/rminhash/rho.rs
@@ -9,6 +9,7 @@ use crate::rminhash::token::{
   token_bytes_ref_from_bytes_ptr, token_bytes_ref_from_token_ptr,
   token_bytes_ref_from_unicode_ptr, TokenBytesRef,
 };
+use crate::rminhash::SharedPermutations;
 use crate::rminhash::{
   DigestBuildConfig, RMinHash, RMinHashDigestMatrix,
   DEFAULT_RHO_LONG_DOC_FACTOR, DEFAULT_RHO_MEDIUM_TOKEN_BUDGET,
@@ -21,13 +22,14 @@ use crate::rminhash::{
   MIN_RHO_MEDIUM_TOKEN_BUDGET, MIN_RHO_MEDIUM_TOKEN_THRESHOLD, MIN_RHO_PROBES,
   MIN_RHO_SPARSE_OCCUPANCY_THRESHOLD_BASE, MIN_RHO_SPARSE_VERIFY_PERM,
 };
-use crate::utils::{calculate_hash_fast, permute_hash};
+use crate::simd::dispatch::{apply_hash_batch_to_values, PermutationSoA};
+use crate::utils::calculate_hash_fast;
 use pyo3::exceptions::PyValueError;
 use pyo3::ffi;
 use pyo3::prelude::*;
 use rayon::prelude::*;
 use std::sync::mpsc;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::thread;
 
 const _: () = assert!(EMPTY_BUCKET == u32::MAX);
@@ -493,7 +495,7 @@ fn append_sparse_sidecar_for_row(
   sparse_occupancy_threshold: usize,
   sparse_verify_perm: usize,
   mixed_token_values: &[u64],
-  signature_pairs: &[(u64, u64)],
+  signature_permutations: &SharedPermutations,
   sparse_verify_active: &mut Vec<u8>,
   sparse_verify_signatures: &mut Vec<u32>,
 ) {
@@ -510,7 +512,7 @@ fn append_sparse_sidecar_for_row(
       &mut sparse_verify_signatures
         [signature_start..signature_start + sparse_verify_perm],
       mixed_token_values,
-      signature_pairs,
+      signature_permutations,
     );
   }
 }
@@ -625,32 +627,32 @@ impl RMinHash {
     )
   }
 
-  pub(super) fn sparse_verify_signature_pairs(
+  pub(super) fn sparse_verify_permutations(
     seed: u64,
     sparse_verify_perm: usize,
-  ) -> Vec<(u64, u64)> {
-    (0..sparse_verify_perm)
+  ) -> SharedPermutations {
+    let pairs: Arc<[(u64, u64)]> = (0..sparse_verify_perm)
       .map(|index| {
         let base = Self::sparse_verify_signature_seed(seed, index);
         (base | 1, splitmix64(base ^ 0x1319_8a2e_0370_7344))
       })
-      .collect()
+      .collect();
+    let soa = Arc::new(PermutationSoA::from_permutations(&pairs));
+    SharedPermutations { pairs, soa }
   }
 
   pub(super) fn compute_sparse_verify_signature_into(
     signature_row: &mut [u32],
     mixed_token_values: &[u64],
-    signature_pairs: &[(u64, u64)],
+    signature_permutations: &SharedPermutations,
   ) {
     signature_row.fill(u32::MAX);
-    if mixed_token_values.is_empty() {
-      return;
-    }
-    for &mixed in mixed_token_values {
-      for (value, &(a, b)) in signature_row.iter_mut().zip(signature_pairs) {
-        *value = (*value).min(permute_hash(mixed, a, b));
-      }
-    }
+    apply_hash_batch_to_values(
+      signature_row,
+      &signature_permutations.pairs,
+      &signature_permutations.soa,
+      mixed_token_values,
+    );
   }
 
   pub(super) fn compute_rho_digest_from_token_hashes_into(
@@ -795,8 +797,8 @@ impl RMinHash {
 
     let py = token_sets.py();
 
-    let sig_pairs =
-      Self::sparse_verify_signature_pairs(seed, sparse_verify_perm);
+    let sig_permutations =
+      Self::sparse_verify_permutations(seed, sparse_verify_perm);
 
     let chunk_size = config.doc_chunk_size.max(1);
     let output_ptrs = RhoOutputs {
@@ -942,7 +944,7 @@ impl RMinHash {
                   Self::compute_sparse_verify_signature_into(
                     signature_row,
                     mixed_values,
-                    &sig_pairs,
+                    &sig_permutations,
                   );
                 }
               },
@@ -1155,8 +1157,8 @@ impl RMinHash {
     let sparse_occupancy_threshold = sketch.sparse_occupancy_threshold;
     let sparse_verify_perm = sketch.sparse_verify_perm;
     let densify_enabled = sketch.densify_enabled;
-    let sig_pairs =
-      Self::sparse_verify_signature_pairs(seed, sparse_verify_perm);
+    let sig_permutations =
+      Self::sparse_verify_permutations(seed, sparse_verify_perm);
     let mut token_hashes = Vec::new();
     let mut mixed_values = Vec::new();
     let mut non_empty_counts = Vec::with_capacity(capacity);
@@ -1209,7 +1211,7 @@ impl RMinHash {
         sparse_occupancy_threshold,
         sparse_verify_perm,
         &mixed_values,
-        &sig_pairs,
+        &sig_permutations,
         &mut sparse_verify_active,
         &mut sparse_verify_signatures,
       );
@@ -1254,8 +1256,8 @@ impl RMinHash {
     let sparse_occupancy_threshold = sketch.sparse_occupancy_threshold;
     let sparse_verify_perm = sketch.sparse_verify_perm;
     let densify_enabled = sketch.densify_enabled;
-    let sig_pairs =
-      Self::sparse_verify_signature_pairs(seed, sparse_verify_perm);
+    let sig_permutations =
+      Self::sparse_verify_permutations(seed, sparse_verify_perm);
     let mut token_hashes = Vec::new();
     let mut mixed_values = Vec::new();
     let mut non_empty_counts = Vec::with_capacity(capacity);
@@ -1304,7 +1306,7 @@ impl RMinHash {
         sparse_occupancy_threshold,
         sparse_verify_perm,
         &mixed_values,
-        &sig_pairs,
+        &sig_permutations,
         &mut sparse_verify_active,
         &mut sparse_verify_signatures,
       );
@@ -1349,8 +1351,8 @@ impl RMinHash {
     let sparse_occupancy_threshold = sketch.sparse_occupancy_threshold;
     let sparse_verify_perm = sketch.sparse_verify_perm;
     let densify_enabled = sketch.densify_enabled;
-    let sig_pairs =
-      Self::sparse_verify_signature_pairs(seed, sparse_verify_perm);
+    let sig_permutations =
+      Self::sparse_verify_permutations(seed, sparse_verify_perm);
     let mut mixed_values = Vec::new();
     let mut non_empty_counts = Vec::with_capacity(rows);
     let mut source_token_counts = Vec::with_capacity(rows);
@@ -1388,7 +1390,7 @@ impl RMinHash {
         sparse_occupancy_threshold,
         sparse_verify_perm,
         &mixed_values,
-        &sig_pairs,
+        &sig_permutations,
         &mut sparse_verify_active,
         &mut sparse_verify_signatures,
       );
@@ -1407,5 +1409,52 @@ impl RMinHash {
       data: matrix_data,
       rho_sidecar: Some(rho_sidecar),
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::rminhash::RMinHash;
+  use rand_core::{RngCore, SeedableRng};
+  use rand_xoshiro::Xoshiro256PlusPlus;
+
+  #[test]
+  fn sparse_verification_matches_independent_wrapping_oracle() {
+    for seed in [0, 42, u64::MAX] {
+      let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
+      for num_perm in [0, 1, 8, 17, 64] {
+        let permutations = RMinHash::sparse_verify_permutations(seed, num_perm);
+        for token_count in [0, 1, 7, 8, 15, 16, 31, 32, 64, 65, 129] {
+          let mixed: Vec<u64> = (0..token_count)
+            .map(|index| match index {
+              0 => 0,
+              1 => u64::MAX,
+              _ => rng.next_u64(),
+            })
+            .collect();
+          let expected: Vec<u32> = permutations
+            .pairs
+            .iter()
+            .map(|&(a, b)| {
+              mixed
+                .iter()
+                .map(|&hash| {
+                  (a.wrapping_mul(hash).wrapping_add(b) >> 32) as u32
+                })
+                .min()
+                .unwrap_or(u32::MAX)
+            })
+            .collect();
+          // Every call resets its output, including when no tokens are present.
+          let mut actual = vec![0; num_perm];
+          RMinHash::compute_sparse_verify_signature_into(
+            &mut actual,
+            &mixed,
+            &permutations,
+          );
+          assert_eq!(actual, expected);
+        }
+      }
+    }
   }
 }

--- a/src/rminhash/rho_raw.rs
+++ b/src/rminhash/rho_raw.rs
@@ -375,8 +375,20 @@ impl RMinHash {
     let mut mixed_values = Vec::new();
     for &row_u32 in fallback_rows {
       let row_index = row_u32 as usize;
-      let document_ptr =
-        unsafe { seq_get_item(ctx.outer.0, ctx.outer_is_list, row_index) };
+      // Row indices were bounded by the original Python sequence length.
+      #[allow(clippy::cast_possible_wrap)]
+      let row_index_ssize = row_index as ffi::Py_ssize_t;
+      // A previous fallback exporter may have resized the outer list.
+      let document_ptr = unsafe {
+        if ctx.outer_is_list {
+          ffi::PyList_GetItem(ctx.outer.0, row_index_ssize)
+        } else {
+          seq_get_item(ctx.outer.0, false, row_index)
+        }
+      };
+      if document_ptr.is_null() {
+        return Err(PyErr::fetch(py));
+      }
       let document =
         unsafe { Bound::<'_, PyAny>::from_borrowed_ptr(py, document_ptr) };
 

--- a/src/rminhash/rho_raw.rs
+++ b/src/rminhash/rho_raw.rs
@@ -8,7 +8,8 @@ use crate::rminhash::rho::{
   saturating_u16, MidpointSampler, RhoSketchConfig,
 };
 use crate::rminhash::{
-  DigestBuildConfig, RMinHash, RMinHashDigestMatrix, EMPTY_BUCKET,
+  DigestBuildConfig, RMinHash, RMinHashDigestMatrix, SharedPermutations,
+  EMPTY_BUCKET,
 };
 use crate::utils::calculate_hash_fast;
 use pyo3::ffi;
@@ -229,8 +230,8 @@ impl RMinHash {
     let sketch = RhoSketchConfig::from_env(num_perm, probes);
     let sparse_verify_perm = sketch.sparse_verify_perm;
     let sparse_occupancy_threshold = sketch.sparse_occupancy_threshold;
-    let sig_pairs =
-      Self::sparse_verify_signature_pairs(seed, sparse_verify_perm);
+    let sig_permutations =
+      Self::sparse_verify_permutations(seed, sparse_verify_perm);
 
     let matrix_len = checked_len_mul(rows, num_perm, "rho matrix")?;
     let mut matrix_storage: Vec<MaybeUninit<u32>> =
@@ -310,7 +311,7 @@ impl RMinHash {
               Self::compute_sparse_verify_signature_into(
                 signature_row,
                 mixed_values,
-                &sig_pairs,
+                &sig_permutations,
               );
             }
             None
@@ -337,7 +338,7 @@ impl RMinHash {
         &mut source_token_counts,
         &mut sparse_verify_active,
         &mut sparse_verify_signatures,
-        &sig_pairs,
+        &sig_permutations,
       )?;
     }
 
@@ -368,7 +369,7 @@ impl RMinHash {
     source_token_counts: &mut [u16],
     sparse_verify_active: &mut [u8],
     sparse_verify_signatures: &mut [u32],
-    sig_pairs: &[(u64, u64)],
+    sig_permutations: &SharedPermutations,
   ) -> PyResult<()> {
     let sketch = &ctx.sketch;
     let mut token_hashes = Vec::new();
@@ -437,7 +438,7 @@ impl RMinHash {
           Self::compute_sparse_verify_signature_into(
             signature_row,
             &mixed_values,
-            sig_pairs,
+            sig_permutations,
           );
         } else {
           signature_row.fill(u32::MAX);

--- a/src/simd/arm64_neon.rs
+++ b/src/simd/arm64_neon.rs
@@ -62,27 +62,28 @@ pub(super) fn apply_hash_batch_to_values_neon(
 }
 
 #[inline]
-pub(super) fn apply_hash_batch_to_values_neon_compact(
+pub(super) fn apply_hash_batch_to_values_neon_compact<const N: usize>(
   hash_values: &mut [u32],
-  permutations: &[(u64, u64); 8],
+  permutations: &[(u64, u64); N],
   hash_batch: &[u64],
 ) {
-  let a_hi: [_; 8] =
-    std::array::from_fn(|index| split_u64_words(permutations[index].0).1);
-  let a_lo: [_; 8] =
-    std::array::from_fn(|index| split_u64_words(permutations[index].0).0);
-  let b_hi: [_; 8] =
-    std::array::from_fn(|index| split_u64_words(permutations[index].1).1);
-  let b_lo: [_; 8] =
-    std::array::from_fn(|index| split_u64_words(permutations[index].1).0);
+  let len = hash_values.len().min(permutations.len());
+  let mut a_hi = [0; N];
+  let mut a_lo = [0; N];
+  let mut b_hi = [0; N];
+  let mut b_lo = [0; N];
+  for (index, &(a, b)) in permutations[..len].iter().enumerate() {
+    (a_lo[index], a_hi[index]) = split_u64_words(a);
+    (b_lo[index], b_hi[index]) = split_u64_words(b);
+  }
   // SAFETY: dispatch guarantees NEON support before calling this function.
   unsafe {
     apply_hash_batch_to_values_neon_impl(
       hash_values,
-      &a_hi,
-      &a_lo,
-      &b_hi,
-      &b_lo,
+      &a_hi[..len],
+      &a_lo[..len],
+      &b_hi[..len],
+      &b_lo[..len],
       hash_batch,
     );
   }

--- a/src/simd/arm64_neon.rs
+++ b/src/simd/arm64_neon.rs
@@ -1,9 +1,9 @@
 use crate::simd::dispatch::{split_u64_words, PermutationSoA};
 use crate::utils::permute_hash;
 use core::arch::aarch64::{
-  uint32x2_t, uint64x2_t, vaddq_u64, vandq_u64, vcombine_u32, vdup_n_u32,
-  vdupq_n_u64, vget_high_u32, vget_low_u32, vld1q_u32, vminq_u32, vmovl_u32,
-  vmovn_u64, vmull_u32, vshrq_n_u64, vst1q_u32,
+  uint32x4_t, uint64x2_t, vaddq_u64, vcombine_u32, vdupq_n_u32, vget_high_u32,
+  vget_low_u32, vld1q_u32, vminq_u32, vmlaq_u32, vmovl_u32, vmovn_u64,
+  vmull_u32, vshrq_n_u64, vsliq_n_u64, vst1q_u32,
 };
 
 #[inline]
@@ -12,31 +12,28 @@ fn combine_u32_words(low: u32, high: u32) -> u64 {
 }
 
 #[inline]
-unsafe fn permute_two_lanes(
-  a_lo: uint32x2_t,
-  a_hi: uint32x2_t,
-  b_lo64: uint64x2_t,
-  b_hi64: uint64x2_t,
-  h_lo_vec: uint32x2_t,
-  h_hi_vec: uint32x2_t,
-  mask32: uint64x2_t,
-) -> uint32x2_t {
-  // SAFETY: caller guarantees execution only in a NEON-enabled context.
-  unsafe {
-    let ll = vmull_u32(a_lo, h_lo_vec);
-    let mid_1 = vmull_u32(a_hi, h_lo_vec);
-    let mid_2 = vmull_u32(a_lo, h_hi_vec);
-    let mid = vaddq_u64(mid_1, mid_2);
-
-    let ll_hi = vshrq_n_u64(ll, 32);
-    let mid_lo = vandq_u64(mid, mask32);
-
-    let hi = vaddq_u64(vaddq_u64(ll_hi, mid_lo), b_hi64);
-    let low = vaddq_u64(vandq_u64(ll, mask32), b_lo64);
-    let carry = vshrq_n_u64(low, 32);
-    let hi_with_carry = vaddq_u64(hi, carry);
-    vmovn_u64(hi_with_carry)
-  }
+#[target_feature(enable = "neon")]
+unsafe fn permute_four_lanes(
+  a_lo: uint32x4_t,
+  a_hi: uint32x4_t,
+  offset01: uint64x2_t,
+  offset23: uint64x2_t,
+  h_lo: uint32x4_t,
+  h_hi: uint32x4_t,
+) -> uint32x4_t {
+  // In arithmetic modulo 2^64, a*h+b = a_lo*h_lo+b +
+  // ((a_hi*h_lo + a_lo*h_hi) << 32). Adding full b includes the carry.
+  let low =
+    vaddq_u64(vmull_u32(vget_low_u32(a_lo), vget_low_u32(h_lo)), offset01);
+  let high = vaddq_u64(
+    vmull_u32(vget_high_u32(a_lo), vget_high_u32(h_lo)),
+    offset23,
+  );
+  let upper = vcombine_u32(
+    vmovn_u64(vshrq_n_u64(low, 32)),
+    vmovn_u64(vshrq_n_u64(high, 32)),
+  );
+  vmlaq_u32(vmlaq_u32(upper, a_hi, h_lo), a_lo, h_hi)
 }
 
 pub(super) fn apply_hash_batch_to_values_neon(
@@ -72,164 +69,96 @@ unsafe fn apply_hash_batch_to_values_neon_impl(
   let a_lo = permutations_soa.a_lo();
   let b_hi = permutations_soa.b_hi();
   let b_lo = permutations_soa.b_lo();
-  let mask32 = vdupq_n_u64(0xffff_ffff);
-
   let mut index = 0usize;
   while index + 8 <= perm_len {
-    // SAFETY: `index + 7 < perm_len`, and all SoA slices plus `hash_values`
-    // have length >= `perm_len`, so these 4-lane loads are in-bounds.
+    // SAFETY: this chunk is within perm_len, bounded by all slice lengths.
     let a_lo_0 = unsafe { vld1q_u32(a_lo.as_ptr().add(index)) };
     let a_hi_0 = unsafe { vld1q_u32(a_hi.as_ptr().add(index)) };
     let b_lo_0 = unsafe { vld1q_u32(b_lo.as_ptr().add(index)) };
     let b_hi_0 = unsafe { vld1q_u32(b_hi.as_ptr().add(index)) };
-
+    let offset01_0 = vsliq_n_u64(
+      vmovl_u32(vget_low_u32(b_lo_0)),
+      vmovl_u32(vget_low_u32(b_hi_0)),
+      32,
+    );
+    let offset23_0 = vsliq_n_u64(
+      vmovl_u32(vget_high_u32(b_lo_0)),
+      vmovl_u32(vget_high_u32(b_hi_0)),
+      32,
+    );
+    let mut current_0 = unsafe { vld1q_u32(hash_values.as_ptr().add(index)) };
+    // SAFETY: this chunk is within perm_len, bounded by all slice lengths.
     let a_lo_1 = unsafe { vld1q_u32(a_lo.as_ptr().add(index + 4)) };
     let a_hi_1 = unsafe { vld1q_u32(a_hi.as_ptr().add(index + 4)) };
     let b_lo_1 = unsafe { vld1q_u32(b_lo.as_ptr().add(index + 4)) };
     let b_hi_1 = unsafe { vld1q_u32(b_hi.as_ptr().add(index + 4)) };
-    let a_lo_0_lo = vget_low_u32(a_lo_0);
-    let a_lo_0_hi = vget_high_u32(a_lo_0);
-    let a_hi_0_lo = vget_low_u32(a_hi_0);
-    let a_hi_0_hi = vget_high_u32(a_hi_0);
-    let b_lo_0_lo64 = vmovl_u32(vget_low_u32(b_lo_0));
-    let b_lo_0_hi64 = vmovl_u32(vget_high_u32(b_lo_0));
-    let b_hi_0_lo64 = vmovl_u32(vget_low_u32(b_hi_0));
-    let b_hi_0_hi64 = vmovl_u32(vget_high_u32(b_hi_0));
-    let a_lo_1_lo = vget_low_u32(a_lo_1);
-    let a_lo_1_hi = vget_high_u32(a_lo_1);
-    let a_hi_1_lo = vget_low_u32(a_hi_1);
-    let a_hi_1_hi = vget_high_u32(a_hi_1);
-    let b_lo_1_lo64 = vmovl_u32(vget_low_u32(b_lo_1));
-    let b_lo_1_hi64 = vmovl_u32(vget_high_u32(b_lo_1));
-    let b_hi_1_lo64 = vmovl_u32(vget_low_u32(b_hi_1));
-    let b_hi_1_hi64 = vmovl_u32(vget_high_u32(b_hi_1));
-    // SAFETY: same bounds argument as above for `hash_values` chunk loads.
-    let mut current_0 = unsafe { vld1q_u32(hash_values.as_ptr().add(index)) };
+    let offset01_1 = vsliq_n_u64(
+      vmovl_u32(vget_low_u32(b_lo_1)),
+      vmovl_u32(vget_low_u32(b_hi_1)),
+      32,
+    );
+    let offset23_1 = vsliq_n_u64(
+      vmovl_u32(vget_high_u32(b_lo_1)),
+      vmovl_u32(vget_high_u32(b_hi_1)),
+      32,
+    );
     let mut current_1 =
       unsafe { vld1q_u32(hash_values.as_ptr().add(index + 4)) };
-
     for &item_hash in hash_batch {
       let (h_lo, h_hi) = split_u64_words(item_hash);
-      let h_lo_vec = vdup_n_u32(h_lo);
-      let h_hi_vec = vdup_n_u32(h_hi);
-
-      // SAFETY: NEON is enabled for this function by `#[target_feature(enable = "neon")]`.
-      let low_perm_0 = unsafe {
-        permute_two_lanes(
-          a_lo_0_lo,
-          a_hi_0_lo,
-          b_lo_0_lo64,
-          b_hi_0_lo64,
-          h_lo_vec,
-          h_hi_vec,
-          mask32,
-        )
+      let h_lo = vdupq_n_u32(h_lo);
+      let h_hi = vdupq_n_u32(h_hi);
+      // SAFETY: NEON is enabled for this function.
+      let permuted_0 = unsafe {
+        permute_four_lanes(a_lo_0, a_hi_0, offset01_0, offset23_0, h_lo, h_hi)
       };
-      // SAFETY: same feature invariant as above.
-      let high_perm_0 = unsafe {
-        permute_two_lanes(
-          a_lo_0_hi,
-          a_hi_0_hi,
-          b_lo_0_hi64,
-          b_hi_0_hi64,
-          h_lo_vec,
-          h_hi_vec,
-          mask32,
-        )
-      };
-      // SAFETY: same feature invariant as above.
-      let low_perm_1 = unsafe {
-        permute_two_lanes(
-          a_lo_1_lo,
-          a_hi_1_lo,
-          b_lo_1_lo64,
-          b_hi_1_lo64,
-          h_lo_vec,
-          h_hi_vec,
-          mask32,
-        )
-      };
-      // SAFETY: same feature invariant as above.
-      let high_perm_1 = unsafe {
-        permute_two_lanes(
-          a_lo_1_hi,
-          a_hi_1_hi,
-          b_lo_1_hi64,
-          b_hi_1_hi64,
-          h_lo_vec,
-          h_hi_vec,
-          mask32,
-        )
-      };
-      let permuted_0 = vcombine_u32(low_perm_0, high_perm_0);
-      let permuted_1 = vcombine_u32(low_perm_1, high_perm_1);
       current_0 = vminq_u32(current_0, permuted_0);
+      // SAFETY: NEON is enabled for this function.
+      let permuted_1 = unsafe {
+        permute_four_lanes(a_lo_1, a_hi_1, offset01_1, offset23_1, h_lo, h_hi)
+      };
       current_1 = vminq_u32(current_1, permuted_1);
     }
-
-    // SAFETY: same bounds argument as the corresponding loads above.
+    // SAFETY: same bounds as the corresponding loads.
     unsafe {
       vst1q_u32(hash_values.as_mut_ptr().add(index), current_0);
       vst1q_u32(hash_values.as_mut_ptr().add(index + 4), current_1);
     }
     index += 8;
   }
-
   while index + 4 <= perm_len {
-    // SAFETY: `index + 3 < perm_len`, and all slices are length >= `perm_len`.
-    let a_lo_chunk = unsafe { vld1q_u32(a_lo.as_ptr().add(index)) };
-    let a_hi_chunk = unsafe { vld1q_u32(a_hi.as_ptr().add(index)) };
-    let b_lo_chunk = unsafe { vld1q_u32(b_lo.as_ptr().add(index)) };
-    let b_hi_chunk = unsafe { vld1q_u32(b_hi.as_ptr().add(index)) };
-    let a_lo_chunk_lo = vget_low_u32(a_lo_chunk);
-    let a_lo_chunk_hi = vget_high_u32(a_lo_chunk);
-    let a_hi_chunk_lo = vget_low_u32(a_hi_chunk);
-    let a_hi_chunk_hi = vget_high_u32(a_hi_chunk);
-    let b_lo_chunk_lo64 = vmovl_u32(vget_low_u32(b_lo_chunk));
-    let b_lo_chunk_hi64 = vmovl_u32(vget_high_u32(b_lo_chunk));
-    let b_hi_chunk_lo64 = vmovl_u32(vget_low_u32(b_hi_chunk));
-    let b_hi_chunk_hi64 = vmovl_u32(vget_high_u32(b_hi_chunk));
-    // SAFETY: same bounds argument as the preceding loads.
-    let mut current = unsafe { vld1q_u32(hash_values.as_ptr().add(index)) };
-
+    // SAFETY: this chunk is within perm_len, bounded by all slice lengths.
+    let a_lo_0 = unsafe { vld1q_u32(a_lo.as_ptr().add(index)) };
+    let a_hi_0 = unsafe { vld1q_u32(a_hi.as_ptr().add(index)) };
+    let b_lo_0 = unsafe { vld1q_u32(b_lo.as_ptr().add(index)) };
+    let b_hi_0 = unsafe { vld1q_u32(b_hi.as_ptr().add(index)) };
+    let offset01_0 = vsliq_n_u64(
+      vmovl_u32(vget_low_u32(b_lo_0)),
+      vmovl_u32(vget_low_u32(b_hi_0)),
+      32,
+    );
+    let offset23_0 = vsliq_n_u64(
+      vmovl_u32(vget_high_u32(b_lo_0)),
+      vmovl_u32(vget_high_u32(b_hi_0)),
+      32,
+    );
+    let mut current_0 = unsafe { vld1q_u32(hash_values.as_ptr().add(index)) };
     for &item_hash in hash_batch {
       let (h_lo, h_hi) = split_u64_words(item_hash);
-      let h_lo_vec = vdup_n_u32(h_lo);
-      let h_hi_vec = vdup_n_u32(h_hi);
-      // SAFETY: NEON is enabled for this function by `#[target_feature(enable = "neon")]`.
-      let low_perm = unsafe {
-        permute_two_lanes(
-          a_lo_chunk_lo,
-          a_hi_chunk_lo,
-          b_lo_chunk_lo64,
-          b_hi_chunk_lo64,
-          h_lo_vec,
-          h_hi_vec,
-          mask32,
-        )
+      let h_lo = vdupq_n_u32(h_lo);
+      let h_hi = vdupq_n_u32(h_hi);
+      // SAFETY: NEON is enabled for this function.
+      let permuted_0 = unsafe {
+        permute_four_lanes(a_lo_0, a_hi_0, offset01_0, offset23_0, h_lo, h_hi)
       };
-      // SAFETY: same feature invariant as above.
-      let high_perm = unsafe {
-        permute_two_lanes(
-          a_lo_chunk_hi,
-          a_hi_chunk_hi,
-          b_lo_chunk_hi64,
-          b_hi_chunk_hi64,
-          h_lo_vec,
-          h_hi_vec,
-          mask32,
-        )
-      };
-      let permuted = vcombine_u32(low_perm, high_perm);
-      current = vminq_u32(current, permuted);
+      current_0 = vminq_u32(current_0, permuted_0);
     }
-    // SAFETY: same bounds argument as the corresponding loads above.
+    // SAFETY: same bounds as the corresponding loads.
     unsafe {
-      vst1q_u32(hash_values.as_mut_ptr().add(index), current);
+      vst1q_u32(hash_values.as_mut_ptr().add(index), current_0);
     }
     index += 4;
   }
-
   for lane_index in index..perm_len {
     let a = combine_u32_words(a_lo[lane_index], a_hi[lane_index]);
     let b = combine_u32_words(b_lo[lane_index], b_hi[lane_index]);

--- a/src/simd/arm64_neon.rs
+++ b/src/simd/arm64_neon.rs
@@ -52,7 +52,37 @@ pub(super) fn apply_hash_batch_to_values_neon(
   unsafe {
     apply_hash_batch_to_values_neon_impl(
       hash_values,
-      permutations_soa,
+      permutations_soa.a_hi(),
+      permutations_soa.a_lo(),
+      permutations_soa.b_hi(),
+      permutations_soa.b_lo(),
+      hash_batch,
+    );
+  }
+}
+
+#[inline]
+pub(super) fn apply_hash_batch_to_values_neon_compact(
+  hash_values: &mut [u32],
+  permutations: &[(u64, u64); 8],
+  hash_batch: &[u64],
+) {
+  let a_hi: [_; 8] =
+    std::array::from_fn(|index| split_u64_words(permutations[index].0).1);
+  let a_lo: [_; 8] =
+    std::array::from_fn(|index| split_u64_words(permutations[index].0).0);
+  let b_hi: [_; 8] =
+    std::array::from_fn(|index| split_u64_words(permutations[index].1).1);
+  let b_lo: [_; 8] =
+    std::array::from_fn(|index| split_u64_words(permutations[index].1).0);
+  // SAFETY: dispatch guarantees NEON support before calling this function.
+  unsafe {
+    apply_hash_batch_to_values_neon_impl(
+      hash_values,
+      &a_hi,
+      &a_lo,
+      &b_hi,
+      &b_lo,
       hash_batch,
     );
   }
@@ -61,14 +91,13 @@ pub(super) fn apply_hash_batch_to_values_neon(
 #[target_feature(enable = "neon")]
 unsafe fn apply_hash_batch_to_values_neon_impl(
   hash_values: &mut [u32],
-  permutations_soa: &PermutationSoA,
+  a_hi: &[u32],
+  a_lo: &[u32],
+  b_hi: &[u32],
+  b_lo: &[u32],
   hash_batch: &[u64],
 ) {
-  let perm_len = permutations_soa.len().min(hash_values.len());
-  let a_hi = permutations_soa.a_hi();
-  let a_lo = permutations_soa.a_lo();
-  let b_hi = permutations_soa.b_hi();
-  let b_lo = permutations_soa.b_lo();
+  let perm_len = a_hi.len().min(hash_values.len());
   let mut index = 0usize;
   while index + 8 <= perm_len {
     // SAFETY: this chunk is within perm_len, bounded by all slice lengths.

--- a/src/simd/dispatch.rs
+++ b/src/simd/dispatch.rs
@@ -26,10 +26,27 @@ impl Avx512Mixer {
 
   #[inline]
   #[allow(clippy::unused_self)] // Calling requires this checked CPU capability.
-  pub fn mix(self, values: &mut [u64; 8], seed: u64) {
+  pub fn mix(self, values: &[u64; 8], seed: u64) -> [u64; 8] {
     // SAFETY: this capability can only be constructed after runtime detection
     // confirms AVX-512F/DQ support, including the operating system's state.
-    unsafe { crate::simd::x86::splitmix64x8_avx512(values, seed) };
+    unsafe { crate::simd::x86::splitmix64x8_avx512(values.as_ptr(), seed) }
+  }
+
+  #[inline]
+  #[allow(clippy::unused_self)] // Calling requires this checked CPU capability.
+  pub fn mix_cells(
+    self,
+    values: &[pyo3::buffer::ReadOnlyCell<u64>; 8],
+    seed: u64,
+  ) -> [u64; 8] {
+    // SAFETY: this capability proves AVX-512F/DQ support. ReadOnlyCell is
+    // repr(transparent) around UnsafeCell<u64>, with the layout of u64.
+    // Deriving the raw pointer from the whole array preserves its full range
+    // of eight readable values. No shared u64 reference is created over the
+    // interior-mutable cells.
+    unsafe {
+      crate::simd::x86::splitmix64x8_avx512(values.as_ptr().cast::<u64>(), seed)
+    }
   }
 }
 
@@ -506,6 +523,53 @@ mod tests {
       assert_eq!(soa.b_hi[1], 0x0102_0304);
       assert_eq!(soa.b_lo[1], 0x0506_0708);
     }
+  }
+
+  #[test]
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  fn avx512_mixer_reads_python_cells_without_changing_values() {
+    use pyo3::buffer::PyBuffer;
+    use pyo3::prelude::*;
+
+    let Some(mixer) = crate::simd::dispatch::Avx512Mixer::detect() else {
+      return;
+    };
+    let values = [
+      0,
+      1,
+      u64::MAX,
+      u64::MAX - 1,
+      u64::from(u32::MAX),
+      1 << 32,
+      1 << 63,
+      0xaaaa_aaaa_5555_5555,
+    ];
+    Python::initialize();
+    Python::attach(|py| {
+      let array = py.import("array").unwrap();
+      let mut input = vec![17];
+      input.extend(values);
+      input.push(23);
+      let object = array
+        .getattr("array")
+        .unwrap()
+        .call1(("Q", input.clone()))
+        .unwrap();
+      let buffer = PyBuffer::<u64>::get(&object).unwrap();
+      let cells = buffer.as_slice(py).unwrap();
+      let chunk = cells[1..].first_chunk::<8>().unwrap();
+      for seed in [0, 42, u64::MAX] {
+        let expected = mixer.mix(&values, seed);
+        assert_eq!(mixer.mix_cells(chunk, seed), expected);
+      }
+      assert_eq!(
+        cells
+          .iter()
+          .map(pyo3::buffer::ReadOnlyCell::get)
+          .collect::<Vec<_>>(),
+        input
+      );
+    });
   }
 
   #[test]

--- a/src/simd/dispatch.rs
+++ b/src/simd/dispatch.rs
@@ -56,13 +56,15 @@ impl Avx512Mixer {
     values: &[u64; 8],
     seed: u64,
     bound: u32,
-  ) -> Option<([u64; 8], u8)> {
+    output: &mut [u64; 8],
+  ) -> u8 {
     // SAFETY: this capability proves AVX-512F/DQ; the array provides all eight values.
     unsafe {
       crate::simd::x86::splitmix64x8_below_avx512::<RANK_SHIFT>(
         values.as_ptr(),
         seed,
         bound,
+        output,
       )
     }
   }
@@ -74,13 +76,15 @@ impl Avx512Mixer {
     values: &[pyo3::buffer::ReadOnlyCell<u64>; 8],
     seed: u64,
     bound: u32,
-  ) -> Option<([u64; 8], u8)> {
+    output: &mut [u64; 8],
+  ) -> u8 {
     // SAFETY: same whole-array, transparent-layout and feature proof as mix_cells.
     unsafe {
       crate::simd::x86::splitmix64x8_below_avx512::<RANK_SHIFT>(
         values.as_ptr().cast::<u64>(),
         seed,
         bound,
+        output,
       )
     }
   }
@@ -618,14 +622,17 @@ mod tests {
       let buffer = PyBuffer::<u64>::get(&object).unwrap();
       let cells = buffer.as_slice(py).unwrap();
       let chunk = cells[1..].first_chunk::<8>().unwrap();
+      let mut raw_output = [17; 8];
+      let mut cell_output = raw_output;
       for seed in [0, 42, u64::MAX] {
         let expected = mixer.mix(&values, seed);
         assert_eq!(mixer.mix_cells(chunk, seed), expected);
         for bound in [0, 1, 1 << 25, 1 << 30] {
           assert_eq!(
-            mixer.mix_below::<34>(&values, seed, bound),
-            mixer.mix_cells_below::<34>(chunk, seed, bound),
+            mixer.mix_below::<34>(&values, seed, bound, &mut raw_output),
+            mixer.mix_cells_below::<34>(chunk, seed, bound, &mut cell_output),
           );
+          assert_eq!(raw_output, cell_output);
         }
       }
       assert_eq!(

--- a/src/simd/dispatch.rs
+++ b/src/simd/dispatch.rs
@@ -232,6 +232,72 @@ pub fn apply_hash_batch_to_values(
   }
 }
 
+pub fn apply_bucket_fallback(
+  hash_values: &mut [u32],
+  permutations: &[(u64, u64)],
+  hashes: &[u64],
+  rank_bits: u32,
+) {
+  debug_assert!((1..32).contains(&rank_bits));
+  let fallback = u32::MAX << (32 - rank_bits);
+  let discarded = (1 << rank_bits) - 1;
+  let len = hash_values.len().min(permutations.len());
+  let kind = kernel_kind();
+  let mut cursor = 0;
+  while cursor < len {
+    let mut indices = [0; 8];
+    let mut pairs = [(0, 0); 8];
+    let mut values = [u32::MAX; 8];
+    let mut count = 0;
+    while cursor < len && count < 8 {
+      if hash_values[cursor] >= fallback {
+        indices[count] = cursor;
+        pairs[count] = permutations[cursor];
+        // Preserve every raw rank represented by the truncated fraction.
+        values[count] = (hash_values[cursor] << rank_bits) | discarded;
+        count += 1;
+      }
+      cursor += 1;
+    }
+    if count == 0 {
+      break;
+    }
+    if count < 4 {
+      for (value, &(a, b)) in values[..count].iter_mut().zip(&pairs) {
+        for &hash in hashes {
+          *value = (*value).min(permute_hash(hash, a, b));
+        }
+      }
+    } else {
+      match kind {
+        KernelKind::Scalar => {
+          scalar_apply_hash_batch_to_values(&mut values, &pairs, hashes);
+        }
+        #[cfg(target_arch = "aarch64")]
+        KernelKind::Neon => {
+          let lanes = if count == 4 { 4 } else { 8 };
+          crate::simd::arm64_neon::apply_hash_batch_to_values_neon_compact(
+            &mut values[..lanes],
+            &pairs,
+            hashes,
+          );
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        KernelKind::Avx2 => {
+          crate::simd::x86::apply_hash_batch_to_values_avx2(
+            &mut values,
+            &pairs,
+            hashes,
+          );
+        }
+      }
+    }
+    for (&index, &value) in indices[..count].iter().zip(&values) {
+      hash_values[index] = fallback | (value >> rank_bits);
+    }
+  }
+}
+
 fn scalar_apply_hash_batch_to_values(
   hash_values: &mut [u32],
   permutations: &[(u64, u64)],

--- a/src/simd/dispatch.rs
+++ b/src/simd/dispatch.rs
@@ -48,6 +48,42 @@ impl Avx512Mixer {
       crate::simd::x86::splitmix64x8_avx512(values.as_ptr().cast::<u64>(), seed)
     }
   }
+
+  #[inline]
+  #[allow(clippy::unused_self)]
+  pub fn mix_below<const RANK_SHIFT: u32>(
+    self,
+    values: &[u64; 8],
+    seed: u64,
+    bound: u32,
+  ) -> Option<([u64; 8], u8)> {
+    // SAFETY: this capability proves AVX-512F/DQ; the array provides all eight values.
+    unsafe {
+      crate::simd::x86::splitmix64x8_below_avx512::<RANK_SHIFT>(
+        values.as_ptr(),
+        seed,
+        bound,
+      )
+    }
+  }
+
+  #[inline]
+  #[allow(clippy::unused_self)]
+  pub fn mix_cells_below<const RANK_SHIFT: u32>(
+    self,
+    values: &[pyo3::buffer::ReadOnlyCell<u64>; 8],
+    seed: u64,
+    bound: u32,
+  ) -> Option<([u64; 8], u8)> {
+    // SAFETY: same whole-array, transparent-layout and feature proof as mix_cells.
+    unsafe {
+      crate::simd::x86::splitmix64x8_below_avx512::<RANK_SHIFT>(
+        values.as_ptr().cast::<u64>(),
+        seed,
+        bound,
+      )
+    }
+  }
 }
 
 #[derive(Clone, Default)]
@@ -285,6 +321,17 @@ pub fn apply_hash_batch_to_values(
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     KernelKind::Avx512 => {
+      if hash_batch.len() == 1
+        && hash_values.len() >= 512
+        && forced_kernel_supported(KernelKind::Avx2)
+      {
+        crate::simd::x86::apply_hash_batch_to_values_avx2(
+          hash_values,
+          permutations,
+          hash_batch,
+        );
+        return;
+      }
       // SAFETY: this dispatch variant requires AVX-512F/DQ CPU/OS support.
       unsafe {
         crate::simd::x86_avx512::apply_hash_batch_to_values_avx512(
@@ -309,6 +356,19 @@ pub fn apply_bucket_fallback(
   let discarded = (1 << rank_bits) - 1;
   let len = hash_values.len().min(permutations.len());
   let kind = kernel_kind();
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  if hashes.len() > 32 && kind == KernelKind::Avx512 {
+    // SAFETY: this dispatch variant requires AVX-512F/DQ CPU/OS support.
+    unsafe {
+      crate::simd::x86_avx512::apply_bucket_fallback_avx512(
+        hash_values,
+        permutations,
+        hashes,
+        rank_bits,
+      );
+    }
+    return;
+  }
   let mut cursor = 0;
   while cursor < len {
     let mut indices = [0; PACKED_LANES];
@@ -561,6 +621,12 @@ mod tests {
       for seed in [0, 42, u64::MAX] {
         let expected = mixer.mix(&values, seed);
         assert_eq!(mixer.mix_cells(chunk, seed), expected);
+        for bound in [0, 1, 1 << 25, 1 << 30] {
+          assert_eq!(
+            mixer.mix_below::<34>(&values, seed, bound),
+            mixer.mix_cells_below::<34>(chunk, seed, bound),
+          );
+        }
       }
       assert_eq!(
         cells

--- a/src/simd/dispatch.rs
+++ b/src/simd/dispatch.rs
@@ -238,6 +238,7 @@ pub fn apply_bucket_fallback(
   hashes: &[u64],
   rank_bits: u32,
 ) {
+  const PACKED_LANES: usize = 128;
   debug_assert!((1..32).contains(&rank_bits));
   let fallback = u32::MAX << (32 - rank_bits);
   let discarded = (1 << rank_bits) - 1;
@@ -245,11 +246,11 @@ pub fn apply_bucket_fallback(
   let kind = kernel_kind();
   let mut cursor = 0;
   while cursor < len {
-    let mut indices = [0; 8];
-    let mut pairs = [(0, 0); 8];
-    let mut values = [u32::MAX; 8];
+    let mut indices = [0; PACKED_LANES];
+    let mut pairs = [(0, 0); PACKED_LANES];
+    let mut values = [u32::MAX; PACKED_LANES];
     let mut count = 0;
-    while cursor < len && count < 8 {
+    while cursor < len && count < PACKED_LANES {
       if hash_values[cursor] >= fallback {
         indices[count] = cursor;
         pairs[count] = permutations[cursor];
@@ -271,11 +272,19 @@ pub fn apply_bucket_fallback(
     } else {
       match kind {
         KernelKind::Scalar => {
-          scalar_apply_hash_batch_to_values(&mut values, &pairs, hashes);
+          scalar_apply_hash_batch_to_values(
+            &mut values[..count],
+            &pairs[..count],
+            hashes,
+          );
         }
         #[cfg(target_arch = "aarch64")]
         KernelKind::Neon => {
-          let lanes = if count == 4 { 4 } else { 8 };
+          let lanes = if count == 4 {
+            4
+          } else {
+            count.next_multiple_of(8)
+          };
           crate::simd::arm64_neon::apply_hash_batch_to_values_neon_compact(
             &mut values[..lanes],
             &pairs,
@@ -284,9 +293,10 @@ pub fn apply_bucket_fallback(
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         KernelKind::Avx2 => {
+          let lanes = count.next_multiple_of(8);
           crate::simd::x86::apply_hash_batch_to_values_avx2(
-            &mut values,
-            &pairs,
+            &mut values[..lanes],
+            &pairs[..lanes],
             hashes,
           );
         }

--- a/src/simd/dispatch.rs
+++ b/src/simd/dispatch.rs
@@ -33,7 +33,7 @@ pub(super) const fn split_u64_words(value: u64) -> (u32, u32) {
 impl PermutationSoA {
   #[must_use]
   #[cfg(not(target_arch = "aarch64"))]
-  pub fn from_permutations(permutations: &[(u64, u64)]) -> Self {
+  pub const fn from_permutations(permutations: &[(u64, u64)]) -> Self {
     Self {
       len: permutations.len(),
     }
@@ -436,6 +436,87 @@ mod tests {
         }
       }
       assert_eq!(soa_values, reference_values);
+    }
+  }
+
+  fn assert_kernels_match_naive(
+    initial: &[u32],
+    permutations: &[(u64, u64)],
+    hashes: &[u64],
+  ) {
+    let mut expected = initial.to_vec();
+    for (value, &(a, b)) in expected.iter_mut().zip(permutations) {
+      for &hash in hashes {
+        // Independent wide-integer oracle: truncation modulo 2^64, then high word.
+        let result = (u128::from(a) * u128::from(hash) + u128::from(b)) >> 32;
+        *value =
+          (*value).min(u32::try_from(result & u128::from(u32::MAX)).unwrap());
+      }
+    }
+    let mut scalar = initial.to_vec();
+    scalar_apply_hash_batch_to_values(&mut scalar, permutations, hashes);
+    assert_eq!(scalar, expected);
+
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+      let mut actual = initial.to_vec();
+      crate::simd::arm64_neon::apply_hash_batch_to_values_neon(
+        &mut actual,
+        &PermutationSoA::from_permutations(permutations),
+        hashes,
+      );
+      assert_eq!(actual, expected, "NEON mismatch");
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if std::arch::is_x86_feature_detected!("avx2") {
+      let mut actual = initial.to_vec();
+      crate::simd::x86::apply_hash_batch_to_values_avx2(
+        &mut actual,
+        permutations,
+        hashes,
+      );
+      assert_eq!(actual, expected, "AVX2 mismatch");
+    }
+  }
+
+  #[test]
+  fn kernels_match_naive_for_all_small_sizes_and_tails() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x5441_494c);
+    for num_perm in 0..=33 {
+      let permutations: Vec<_> = (0..num_perm)
+        .map(|_| (rng.next_u64(), rng.next_u64()))
+        .collect();
+      for num_hashes in 0..=17 {
+        let hashes: Vec<_> = (0..num_hashes).map(|_| rng.next_u64()).collect();
+        for num_values in [num_perm / 2, num_perm, num_perm + 3] {
+          let initial: Vec<_> =
+            (0..num_values).map(|_| rng.next_u32()).collect();
+          assert_kernels_match_naive(&initial, &permutations, &hashes);
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn kernels_match_naive_for_full_width_carries_and_overflow() {
+    let words = [0, 1, 0x7fff_ffff, 0x8000_0000, 0xffff_ffff];
+    let mut boundaries = Vec::new();
+    for &high in &words {
+      for &low in &words {
+        boundaries.push((high << 32) | low);
+      }
+    }
+    let permutations: Vec<_> = boundaries
+      .iter()
+      .flat_map(|&a| boundaries.iter().map(move |&b| (a, b)))
+      .collect();
+    for hash in boundaries {
+      // Single hashes ensure a smaller minimum cannot hide an incorrect lane.
+      assert_kernels_match_naive(
+        &vec![u32::MAX; permutations.len()],
+        &permutations,
+        &[hash],
+      );
     }
   }
 }

--- a/src/simd/dispatch.rs
+++ b/src/simd/dispatch.rs
@@ -8,6 +8,29 @@ enum KernelKind {
   Neon,
   #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
   Avx2,
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  Avx512,
+}
+
+/// A runtime-checked capability for eight-lane AVX-512 token mixing.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[derive(Clone, Copy)]
+pub struct Avx512Mixer(());
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl Avx512Mixer {
+  #[must_use]
+  pub fn detect() -> Option<Self> {
+    matches!(kernel_kind(), KernelKind::Avx512).then_some(Self(()))
+  }
+
+  #[inline]
+  #[allow(clippy::unused_self)] // Calling requires this checked CPU capability.
+  pub fn mix(self, values: &mut [u64; 8], seed: u64) {
+    // SAFETY: this capability can only be constructed after runtime detection
+    // confirms AVX-512F/DQ support, including the operating system's state.
+    unsafe { crate::simd::x86::splitmix64x8_avx512(values, seed) };
+  }
 }
 
 #[derive(Clone, Default)]
@@ -123,6 +146,8 @@ const fn kernel_kind_name(kind: KernelKind) -> &'static str {
     KernelKind::Neon => "neon",
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     KernelKind::Avx2 => "avx2",
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    KernelKind::Avx512 => "avx512",
   }
 }
 
@@ -145,6 +170,11 @@ fn forced_kernel_supported(kind: KernelKind) -> bool {
     KernelKind::Neon => std::arch::is_aarch64_feature_detected!("neon"),
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     KernelKind::Avx2 => std::arch::is_x86_feature_detected!("avx2"),
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    KernelKind::Avx512 => {
+      std::arch::is_x86_feature_detected!("avx512f")
+        && std::arch::is_x86_feature_detected!("avx512dq")
+    }
   }
 }
 
@@ -164,6 +194,11 @@ fn parse_forced_kernel(value: &str) -> Option<KernelKind> {
     return Some(KernelKind::Avx2);
   }
 
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  if value.eq_ignore_ascii_case("avx512") {
+    return Some(KernelKind::Avx512);
+  }
+
   None
 }
 
@@ -178,7 +213,9 @@ fn default_kernel_kind() -> KernelKind {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn default_kernel_kind() -> KernelKind {
-  if std::arch::is_x86_feature_detected!("avx2") {
+  if forced_kernel_supported(KernelKind::Avx512) {
+    KernelKind::Avx512
+  } else if std::arch::is_x86_feature_detected!("avx2") {
     KernelKind::Avx2
   } else {
     KernelKind::Scalar
@@ -228,6 +265,17 @@ pub fn apply_hash_batch_to_values(
         permutations,
         hash_batch,
       );
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    KernelKind::Avx512 => {
+      // SAFETY: this dispatch variant requires AVX-512F/DQ CPU/OS support.
+      unsafe {
+        crate::simd::x86_avx512::apply_hash_batch_to_values_avx512(
+          hash_values,
+          permutations,
+          hash_batch,
+        );
+      }
     }
   }
 }
@@ -299,6 +347,18 @@ pub fn apply_bucket_fallback(
             &pairs[..lanes],
             hashes,
           );
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        KernelKind::Avx512 => {
+          let lanes = count.next_multiple_of(8);
+          // SAFETY: this dispatch variant requires AVX-512F/DQ CPU/OS support.
+          unsafe {
+            crate::simd::x86_avx512::apply_hash_batch_to_values_avx512(
+              &mut values[..lanes],
+              &pairs[..lanes],
+              hashes,
+            );
+          }
         }
       }
     }
@@ -423,8 +483,9 @@ fn scalar_apply_hash_batch_to_values(
 #[cfg(test)]
 mod tests {
   use crate::simd::dispatch::{
-    forced_kernel_supported, kernel_kind_name, parse_forced_kernel,
-    scalar_apply_hash_batch_to_values, KernelKind, PermutationSoA,
+    forced_kernel_supported, kernel_kind, kernel_kind_name,
+    parse_forced_kernel, scalar_apply_hash_batch_to_values, KernelKind,
+    PermutationSoA,
   };
   use crate::utils::permute_hash;
   use rand_core::{RngCore, SeedableRng};
@@ -454,6 +515,8 @@ mod tests {
     assert_eq!(kernel_kind_name(KernelKind::Neon), "neon");
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     assert_eq!(kernel_kind_name(KernelKind::Avx2), "avx2");
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    assert_eq!(kernel_kind_name(KernelKind::Avx512), "avx512");
   }
 
   #[test]
@@ -464,11 +527,21 @@ mod tests {
     assert_eq!(parse_forced_kernel("neon"), Some(KernelKind::Neon));
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     assert_eq!(parse_forced_kernel("avx2"), Some(KernelKind::Avx2));
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    assert_eq!(parse_forced_kernel("AVX512"), Some(KernelKind::Avx512));
     assert_eq!(parse_forced_kernel("unknown"), None);
   }
 
   #[test]
   fn forced_kernel_support_mapping_matches_runtime() {
+    eprintln!(
+      "Rensa selected SIMD backend: {}",
+      kernel_kind_name(kernel_kind())
+    );
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if std::env::var_os("RENSA_REQUIRE_AVX512").is_some() {
+      assert_eq!(kernel_kind(), KernelKind::Avx512);
+    }
     assert!(forced_kernel_supported(KernelKind::Scalar));
     #[cfg(target_arch = "aarch64")]
     assert_eq!(
@@ -479,6 +552,12 @@ mod tests {
     assert_eq!(
       forced_kernel_supported(KernelKind::Avx2),
       std::arch::is_x86_feature_detected!("avx2")
+    );
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    assert_eq!(
+      forced_kernel_supported(KernelKind::Avx512),
+      std::arch::is_x86_feature_detected!("avx512f")
+        && std::arch::is_x86_feature_detected!("avx512dq")
     );
   }
 

--- a/src/simd/dispatch.rs
+++ b/src/simd/dispatch.rs
@@ -51,6 +51,7 @@ impl Avx512Mixer {
 
   #[inline]
   #[allow(clippy::unused_self)]
+  #[cfg(target_arch = "x86")]
   pub fn mix_below<const RANK_SHIFT: u32>(
     self,
     values: &[u64; 8],
@@ -71,6 +72,7 @@ impl Avx512Mixer {
 
   #[inline]
   #[allow(clippy::unused_self)]
+  #[cfg(target_arch = "x86")]
   pub fn mix_cells_below<const RANK_SHIFT: u32>(
     self,
     values: &[pyo3::buffer::ReadOnlyCell<u64>; 8],
@@ -85,6 +87,51 @@ impl Avx512Mixer {
         seed,
         bound,
         output,
+      )
+    }
+  }
+
+  #[cfg(target_arch = "x86_64")]
+  #[allow(clippy::unused_self)]
+  pub fn apply_below(
+    self,
+    input: &[u64],
+    seed: u64,
+    bound: u32,
+    hash_values: &mut [u32],
+  ) -> usize {
+    // SAFETY: this capability proves F/DQ and the whole slice proves the
+    // readable input extent. The kernel checks coordinate dimensions.
+    unsafe {
+      crate::simd::x86::apply_buckets_below_avx512(
+        input.as_ptr(),
+        input.len(),
+        seed,
+        bound,
+        hash_values,
+      )
+    }
+  }
+
+  #[cfg(target_arch = "x86_64")]
+  #[allow(clippy::unused_self)]
+  pub fn apply_cells_below(
+    self,
+    input: &[pyo3::buffer::ReadOnlyCell<u64>],
+    seed: u64,
+    bound: u32,
+    hash_values: &mut [u32],
+  ) -> usize {
+    // SAFETY: F/DQ is established. This pointer is derived from the whole
+    // transparent-layout cell slice, without creating shared u64 references.
+    // The kernel checks coordinate dimensions before accessing any bucket.
+    unsafe {
+      crate::simd::x86::apply_buckets_below_avx512(
+        input.as_ptr().cast::<u64>(),
+        input.len(),
+        seed,
+        bound,
+        hash_values,
       )
     }
   }
@@ -622,17 +669,30 @@ mod tests {
       let buffer = PyBuffer::<u64>::get(&object).unwrap();
       let cells = buffer.as_slice(py).unwrap();
       let chunk = cells[1..].first_chunk::<8>().unwrap();
-      let mut raw_output = [17; 8];
-      let mut cell_output = raw_output;
       for seed in [0, 42, u64::MAX] {
+        #[cfg(target_arch = "x86")]
+        let mut raw_output = [17; 8];
+        #[cfg(target_arch = "x86_64")]
+        let mut raw_output = [u32::MAX; 8];
+        let mut cell_output = raw_output;
         let expected = mixer.mix(&values, seed);
         assert_eq!(mixer.mix_cells(chunk, seed), expected);
         for bound in [0, 1, 1 << 25, 1 << 30] {
+          #[cfg(target_arch = "x86")]
           assert_eq!(
             mixer.mix_below::<34>(&values, seed, bound, &mut raw_output),
             mixer.mix_cells_below::<34>(chunk, seed, bound, &mut cell_output),
           );
+          #[cfg(target_arch = "x86_64")]
+          assert_eq!(
+            mixer.apply_below(&values, seed, bound, &mut raw_output),
+            mixer.apply_cells_below(chunk, seed, bound, &mut cell_output),
+          );
           assert_eq!(raw_output, cell_output);
+          #[cfg(target_arch = "x86_64")]
+          if bound == 1 << 30 {
+            assert!(raw_output.iter().any(|&value| value != u32::MAX));
+          }
         }
       }
       assert_eq!(

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -5,3 +5,6 @@ mod arm64_neon;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86_avx512;

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -2,11 +2,15 @@ use crate::utils::permute_hash;
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
-  __m256i, _mm256_loadu_si256, _mm256_min_epu32, _mm256_storeu_si256,
+  __m256i, _mm256_add_epi32, _mm256_add_epi64, _mm256_blend_epi32,
+  _mm256_loadu_si256, _mm256_min_epu32, _mm256_mul_epu32, _mm256_mullo_epi32,
+  _mm256_set1_epi32, _mm256_srli_epi64, _mm256_storeu_si256,
 };
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{
-  __m256i, _mm256_loadu_si256, _mm256_min_epu32, _mm256_storeu_si256,
+  __m256i, _mm256_add_epi32, _mm256_add_epi64, _mm256_blend_epi32,
+  _mm256_loadu_si256, _mm256_min_epu32, _mm256_mul_epu32, _mm256_mullo_epi32,
+  _mm256_set1_epi32, _mm256_srli_epi64, _mm256_storeu_si256,
 };
 
 pub(super) fn apply_hash_batch_to_values_avx2(
@@ -31,6 +35,7 @@ pub(super) fn apply_hash_batch_to_values_avx2(
   }
 }
 
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 #[target_feature(enable = "avx2")]
 unsafe fn apply_hash_batch_to_values_avx2_impl(
   hash_values: &mut [u32],
@@ -43,19 +48,32 @@ unsafe fn apply_hash_batch_to_values_avx2_impl(
   for (values, perms) in value_chunks.by_ref().zip(perm_chunks.by_ref()) {
     // SAFETY: `values` comes from `chunks_exact_mut(8)`, so it has exactly 8 lanes.
     let mut current = unsafe { load_u32x8(values.as_ptr()) };
+    // Split coefficients once per chunk, outside the hash loop. Keep the
+    // existing AoS representation so construction and scalar dispatch are unchanged.
+    let a_lo: [u32; 8] = std::array::from_fn(|lane| perms[lane].0 as u32);
+    let a_hi: [u32; 8] =
+      std::array::from_fn(|lane| (perms[lane].0 >> 32) as u32);
+    let b_even: [u64; 4] = std::array::from_fn(|lane| perms[lane * 2].1);
+    let b_odd: [u64; 4] = std::array::from_fn(|lane| perms[lane * 2 + 1].1);
+    // SAFETY: each local array contains exactly 32 readable bytes.
+    let a_lo = unsafe { load_u32x8(a_lo.as_ptr()) };
+    let a_hi = unsafe { load_u32x8(a_hi.as_ptr()) };
+    let b_even = unsafe { load_u32x8(b_even.as_ptr().cast()) };
+    let b_odd = unsafe { load_u32x8(b_odd.as_ptr().cast()) };
+    let a_lo_odd = _mm256_srli_epi64(a_lo, 32);
     for &item_hash in hash_batch {
-      let permuted = [
-        permute_hash(item_hash, perms[0].0, perms[0].1),
-        permute_hash(item_hash, perms[1].0, perms[1].1),
-        permute_hash(item_hash, perms[2].0, perms[2].1),
-        permute_hash(item_hash, perms[3].0, perms[3].1),
-        permute_hash(item_hash, perms[4].0, perms[4].1),
-        permute_hash(item_hash, perms[5].0, perms[5].1),
-        permute_hash(item_hash, perms[6].0, perms[6].1),
-        permute_hash(item_hash, perms[7].0, perms[7].1),
-      ];
-      // SAFETY: `permuted` is a local `[u32; 8]`, valid for an 8-lane load.
-      let permuted_vec = unsafe { load_u32x8(permuted.as_ptr()) };
+      let h_lo = _mm256_set1_epi32(item_hash as i32);
+      let h_hi = _mm256_set1_epi32((item_hash >> 32) as i32);
+      // high32(a*h+b) = high32(a_lo*h_lo+b) + a_hi*h_lo + a_lo*h_hi
+      // modulo 2^32. Full-width b additions include the low-word carry.
+      let even = _mm256_add_epi64(_mm256_mul_epu32(a_lo, h_lo), b_even);
+      let odd = _mm256_add_epi64(_mm256_mul_epu32(a_lo_odd, h_lo), b_odd);
+      let upper = _mm256_blend_epi32(_mm256_srli_epi64(even, 32), odd, 0xaa);
+      let cross = _mm256_add_epi32(
+        _mm256_mullo_epi32(a_hi, h_lo),
+        _mm256_mullo_epi32(a_lo, h_hi),
+      );
+      let permuted_vec = _mm256_add_epi32(upper, cross);
       current = _mm256_min_epu32(current, permuted_vec);
     }
     // SAFETY: `values` is still a valid mutable 8-lane chunk here.
@@ -76,12 +94,14 @@ unsafe fn apply_hash_batch_to_values_avx2_impl(
 }
 
 #[inline]
+#[allow(clippy::cast_ptr_alignment)] // loadu accepts unaligned addresses.
 unsafe fn load_u32x8(ptr: *const u32) -> __m256i {
   // SAFETY: caller guarantees `ptr` is valid for 8 contiguous `u32` values.
   unsafe { _mm256_loadu_si256(ptr.cast::<__m256i>()) }
 }
 
 #[inline]
+#[allow(clippy::cast_ptr_alignment)] // storeu accepts unaligned addresses.
 unsafe fn store_u32x8(ptr: *mut u32, value: __m256i) {
   // SAFETY: caller guarantees `ptr` is valid for 8 contiguous mutable `u32` values.
   unsafe { _mm256_storeu_si256(ptr.cast::<__m256i>(), value) };

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -48,6 +48,20 @@ unsafe fn apply_hash_batch_to_values_avx2_impl(
   for (values, perms) in value_chunks.by_ref().zip(perm_chunks.by_ref()) {
     // SAFETY: `values` comes from `chunks_exact_mut(8)`, so it has exactly 8 lanes.
     let mut current = unsafe { load_u32x8(values.as_ptr()) };
+    // Short batches do not amortize the vector coefficient setup.
+    if hash_batch.len() < 16 {
+      for &item_hash in hash_batch {
+        let permuted: [u32; 8] = std::array::from_fn(|lane| {
+          permute_hash(item_hash, perms[lane].0, perms[lane].1)
+        });
+        // SAFETY: the local array contains eight readable lanes.
+        let permuted = unsafe { load_u32x8(permuted.as_ptr()) };
+        current = _mm256_min_epu32(current, permuted);
+      }
+      // SAFETY: values contains exactly eight writable lanes.
+      unsafe { store_u32x8(values.as_mut_ptr(), current) };
+      continue;
+    }
     // Split coefficients once per chunk, outside the hash loop. Keep the
     // existing AoS representation so construction and scalar dispatch are unchanged.
     let a_lo: [u32; 8] = std::array::from_fn(|lane| perms[lane].0 as u32);

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -50,6 +50,77 @@ pub(super) unsafe fn splitmix64x8_avx512(
   }
 }
 
+/// Rejects a complete block before materializing mixed values when every rank
+/// is at least the supplied bound. Surviving lane positions are returned in mask.
+#[inline]
+pub(super) unsafe fn splitmix64x8_below_avx512<const RANK_SHIFT: u32>(
+  values: *const u64,
+  seed: u64,
+  bound: u32,
+) -> Option<([u64; 8], u8)> {
+  const CONSTANTS: [u64; 3] = [
+    0x9e37_79b9_7f4a_7c15,
+    0xbf58_476d_1ce4_e5b9,
+    0x94d0_49bb_1331_11eb,
+  ];
+  const {
+    assert!(RANK_SHIFT >= 33 && RANK_SHIFT < 64);
+  }
+  let state = [seed, u64::from(bound)];
+  let mut output = std::mem::MaybeUninit::<[u64; 8]>::uninit();
+  let mask: u32;
+  // SAFETY: the caller proves AVX-512F/DQ support and eight readable input
+  // values. Every broadcast reads one initialized u64. The final xor only
+  // changes bits 0..=32, so ranks beginning at bit 33 can be compared first.
+  // A nonzero mask always reaches the full 64-byte output store. No output is
+  // read when the mask is zero; all vector, mask and GPR changes are declared.
+  unsafe {
+    core::arch::asm!(
+      "vmovdqu64 zmm0, [{values}]",
+      "vpbroadcastq zmm1, [{state}]",
+      "vpxorq zmm0, zmm0, zmm1",
+      "vpbroadcastq zmm1, [{constants}]",
+      "vpaddq zmm0, zmm0, zmm1",
+      "vpsrlq zmm2, zmm0, 30",
+      "vpxorq zmm0, zmm0, zmm2",
+      "vpbroadcastq zmm1, [{constants} + 8]",
+      "vpmullq zmm0, zmm0, zmm1",
+      "vpsrlq zmm2, zmm0, 27",
+      "vpxorq zmm0, zmm0, zmm2",
+      "vpbroadcastq zmm1, [{constants} + 16]",
+      "vpmullq zmm0, zmm0, zmm1",
+      "vpsrlq zmm2, zmm0, {rank_shift}",
+      "vpbroadcastq zmm1, [{state} + 8]",
+      "vpcmpuq k1, zmm2, zmm1, 1",
+      "kmovw {mask:e}, k1",
+      "test {mask:e}, {mask:e}",
+      "jz 2f",
+      "vpsrlq zmm2, zmm0, 31",
+      "vpxorq zmm0, zmm0, zmm2",
+      "vmovdqu64 [{output}], zmm0",
+      "2:",
+      values = in(reg) values,
+      state = in(reg) state.as_ptr(),
+      constants = in(reg) CONSTANTS.as_ptr(),
+      output = inout(reg) output.as_mut_ptr() => _,
+      mask = lateout(reg) mask,
+      rank_shift = const RANK_SHIFT,
+      out("zmm0") _,
+      out("zmm1") _,
+      out("zmm2") _,
+      out("k1") _,
+      options(nostack),
+    );
+    if mask == 0 {
+      None
+    } else {
+      // vpcmpuq writes exactly eight mask bits for eight u64 lanes.
+      #[allow(clippy::cast_possible_truncation)]
+      Some((output.assume_init(), mask as u8))
+    }
+  }
+}
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
   __m256i, _mm256_loadu_si256, _mm256_min_epu32, _mm256_storeu_si256,
@@ -179,6 +250,58 @@ mod tests {
         // SAFETY: the test checked both required CPU/OS features above.
         let actual = unsafe { splitmix64x8_avx512(input.as_ptr(), seed) };
         assert_eq!(actual, expected);
+      }
+    }
+  }
+
+  #[test]
+  fn avx512_rank_mask_matches_scalar_at_exact_boundaries() {
+    if !std::arch::is_x86_feature_detected!("avx512f")
+      || !std::arch::is_x86_feature_detected!("avx512dq")
+    {
+      return;
+    }
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x5241_4e4b);
+    for seed in [0, 42, u64::MAX] {
+      for batch in 0..128 {
+        let input = if batch == 0 {
+          [0, 1, u64::MAX, u64::MAX - 1, 1 << 31, 1 << 32, 1 << 63, 42]
+        } else {
+          std::array::from_fn(|_| rng.next_u64())
+        };
+        let expected = input.map(|value| scalar(value, seed));
+        #[allow(clippy::cast_possible_truncation)]
+        let boundary = (expected[batch % 8] >> 34) as u32;
+        for bound in [0, 1, 1 << 25, 1 << 30, u32::MAX, boundary, boundary + 1]
+        {
+          let mask =
+            expected
+              .iter()
+              .enumerate()
+              .fold(0u8, |mask, (lane, &value)| {
+                if value >> 34 < u64::from(bound) {
+                  mask | (1 << lane)
+                } else {
+                  mask
+                }
+              });
+          // SAFETY: CPU/OS support and the complete eight-value input were established above.
+          let actual = unsafe {
+            crate::simd::x86::splitmix64x8_below_avx512::<34>(
+              input.as_ptr(),
+              seed,
+              bound,
+            )
+          };
+          assert_eq!(
+            actual,
+            if mask == 0 {
+              None
+            } else {
+              Some((expected, mask))
+            }
+          );
+        }
       }
     }
   }

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -2,15 +2,11 @@ use crate::utils::permute_hash;
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
-  __m256i, _mm256_add_epi32, _mm256_add_epi64, _mm256_blend_epi32,
-  _mm256_loadu_si256, _mm256_min_epu32, _mm256_mul_epu32, _mm256_mullo_epi32,
-  _mm256_set1_epi32, _mm256_srli_epi64, _mm256_storeu_si256,
+  __m256i, _mm256_loadu_si256, _mm256_min_epu32, _mm256_storeu_si256,
 };
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{
-  __m256i, _mm256_add_epi32, _mm256_add_epi64, _mm256_blend_epi32,
-  _mm256_loadu_si256, _mm256_min_epu32, _mm256_mul_epu32, _mm256_mullo_epi32,
-  _mm256_set1_epi32, _mm256_srli_epi64, _mm256_storeu_si256,
+  __m256i, _mm256_loadu_si256, _mm256_min_epu32, _mm256_storeu_si256,
 };
 
 pub(super) fn apply_hash_batch_to_values_avx2(
@@ -35,7 +31,6 @@ pub(super) fn apply_hash_batch_to_values_avx2(
   }
 }
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 #[target_feature(enable = "avx2")]
 unsafe fn apply_hash_batch_to_values_avx2_impl(
   hash_values: &mut [u32],
@@ -48,46 +43,19 @@ unsafe fn apply_hash_batch_to_values_avx2_impl(
   for (values, perms) in value_chunks.by_ref().zip(perm_chunks.by_ref()) {
     // SAFETY: `values` comes from `chunks_exact_mut(8)`, so it has exactly 8 lanes.
     let mut current = unsafe { load_u32x8(values.as_ptr()) };
-    // Short batches do not amortize the vector coefficient setup.
-    if hash_batch.len() < 16 {
-      for &item_hash in hash_batch {
-        let permuted: [u32; 8] = std::array::from_fn(|lane| {
-          permute_hash(item_hash, perms[lane].0, perms[lane].1)
-        });
-        // SAFETY: the local array contains eight readable lanes.
-        let permuted = unsafe { load_u32x8(permuted.as_ptr()) };
-        current = _mm256_min_epu32(current, permuted);
-      }
-      // SAFETY: values contains exactly eight writable lanes.
-      unsafe { store_u32x8(values.as_mut_ptr(), current) };
-      continue;
-    }
-    // Split coefficients once per chunk, outside the hash loop. Keep the
-    // existing AoS representation so construction and scalar dispatch are unchanged.
-    let a_lo: [u32; 8] = std::array::from_fn(|lane| perms[lane].0 as u32);
-    let a_hi: [u32; 8] =
-      std::array::from_fn(|lane| (perms[lane].0 >> 32) as u32);
-    let b_even: [u64; 4] = std::array::from_fn(|lane| perms[lane * 2].1);
-    let b_odd: [u64; 4] = std::array::from_fn(|lane| perms[lane * 2 + 1].1);
-    // SAFETY: each local array contains exactly 32 readable bytes.
-    let a_lo = unsafe { load_u32x8(a_lo.as_ptr()) };
-    let a_hi = unsafe { load_u32x8(a_hi.as_ptr()) };
-    let b_even = unsafe { load_u32x8(b_even.as_ptr().cast()) };
-    let b_odd = unsafe { load_u32x8(b_odd.as_ptr().cast()) };
-    let a_lo_odd = _mm256_srli_epi64(a_lo, 32);
     for &item_hash in hash_batch {
-      let h_lo = _mm256_set1_epi32(item_hash as i32);
-      let h_hi = _mm256_set1_epi32((item_hash >> 32) as i32);
-      // high32(a*h+b) = high32(a_lo*h_lo+b) + a_hi*h_lo + a_lo*h_hi
-      // modulo 2^32. Full-width b additions include the low-word carry.
-      let even = _mm256_add_epi64(_mm256_mul_epu32(a_lo, h_lo), b_even);
-      let odd = _mm256_add_epi64(_mm256_mul_epu32(a_lo_odd, h_lo), b_odd);
-      let upper = _mm256_blend_epi32(_mm256_srli_epi64(even, 32), odd, 0xaa);
-      let cross = _mm256_add_epi32(
-        _mm256_mullo_epi32(a_hi, h_lo),
-        _mm256_mullo_epi32(a_lo, h_hi),
-      );
-      let permuted_vec = _mm256_add_epi32(upper, cross);
+      let permuted = [
+        permute_hash(item_hash, perms[0].0, perms[0].1),
+        permute_hash(item_hash, perms[1].0, perms[1].1),
+        permute_hash(item_hash, perms[2].0, perms[2].1),
+        permute_hash(item_hash, perms[3].0, perms[3].1),
+        permute_hash(item_hash, perms[4].0, perms[4].1),
+        permute_hash(item_hash, perms[5].0, perms[5].1),
+        permute_hash(item_hash, perms[6].0, perms[6].1),
+        permute_hash(item_hash, perms[7].0, perms[7].1),
+      ];
+      // SAFETY: `permuted` is a local `[u32; 8]`, valid for an 8-lane load.
+      let permuted_vec = unsafe { load_u32x8(permuted.as_ptr()) };
       current = _mm256_min_epu32(current, permuted_vec);
     }
     // SAFETY: `values` is still a valid mutable 8-lane chunk here.

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -50,14 +50,15 @@ pub(super) unsafe fn splitmix64x8_avx512(
   }
 }
 
-/// Rejects a complete block before materializing mixed values when every rank
-/// is at least the supplied bound. Surviving lane positions are returned in mask.
+/// Returns surviving lane positions, writing all mixed values to output only
+/// when at least one rank is below the supplied bound.
 #[inline]
 pub(super) unsafe fn splitmix64x8_below_avx512<const RANK_SHIFT: u32>(
   values: *const u64,
   seed: u64,
   bound: u32,
-) -> Option<([u64; 8], u8)> {
+  output: &mut [u64; 8],
+) -> u8 {
   const CONSTANTS: [u64; 3] = [
     0x9e37_79b9_7f4a_7c15,
     0xbf58_476d_1ce4_e5b9,
@@ -67,13 +68,12 @@ pub(super) unsafe fn splitmix64x8_below_avx512<const RANK_SHIFT: u32>(
     assert!(RANK_SHIFT >= 33 && RANK_SHIFT < 64);
   }
   let state = [seed, u64::from(bound)];
-  let mut output = std::mem::MaybeUninit::<[u64; 8]>::uninit();
   let mask: u32;
   // SAFETY: the caller proves AVX-512F/DQ support and eight readable input
   // values. Every broadcast reads one initialized u64. The final xor only
   // changes bits 0..=32, so ranks beginning at bit 33 can be compared first.
-  // A nonzero mask always reaches the full 64-byte output store. No output is
-  // read when the mask is zero; all vector, mask and GPR changes are declared.
+  // A nonzero mask always reaches the full 64-byte output store; a zero mask
+  // leaves output unchanged. All vector, mask and GPR changes are declared.
   unsafe {
     core::arch::asm!(
       "vmovdqu64 zmm0, [{values}]",
@@ -111,14 +111,11 @@ pub(super) unsafe fn splitmix64x8_below_avx512<const RANK_SHIFT: u32>(
       out("k1") _,
       options(nostack),
     );
-    if mask == 0 {
-      None
-    } else {
-      // vpcmpuq writes exactly eight mask bits for eight u64 lanes.
-      #[allow(clippy::cast_possible_truncation)]
-      Some((output.assume_init(), mask as u8))
-    }
   }
+  // vpcmpuq writes exactly eight mask bits for eight u64 lanes.
+  #[allow(clippy::cast_possible_truncation)]
+  let mask = mask as u8;
+  mask
 }
 
 #[cfg(target_arch = "x86")]
@@ -262,6 +259,7 @@ mod tests {
       return;
     }
     let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x5241_4e4b);
+    let mut output = [u64::MAX; 8];
     for seed in [0, 42, u64::MAX] {
       for batch in 0..128 {
         let input = if batch == 0 {
@@ -285,22 +283,18 @@ mod tests {
                   mask
                 }
               });
+          let before = output;
           // SAFETY: CPU/OS support and the complete eight-value input were established above.
           let actual = unsafe {
             crate::simd::x86::splitmix64x8_below_avx512::<34>(
               input.as_ptr(),
               seed,
               bound,
+              &mut output,
             )
           };
-          assert_eq!(
-            actual,
-            if mask == 0 {
-              None
-            } else {
-              Some((expected, mask))
-            }
-          );
+          assert_eq!(actual, mask);
+          assert_eq!(output, if mask == 0 { before } else { expected });
         }
       }
     }

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -2,17 +2,23 @@ use crate::utils::permute_hash;
 
 /// Mixes eight independent token values; coordinate updates remain scalar.
 #[inline]
-pub(super) unsafe fn splitmix64x8_avx512(values: &mut [u64; 8], seed: u64) {
+pub(super) unsafe fn splitmix64x8_avx512(
+  values: *const u64,
+  seed: u64,
+) -> [u64; 8] {
   const CONSTANTS: [u64; 3] = [
     0x9e37_79b9_7f4a_7c15,
     0xbf58_476d_1ce4_e5b9,
     0x94d0_49bb_1331_11eb,
   ];
-  // SAFETY: the caller proves AVX-512F/DQ support. The unaligned load/store
-  // access exactly the initialized, exclusively borrowed eight-value array;
-  // broadcasts read one seed and three constants. All used vector registers
-  // are declared clobbered. Assembly retains compatibility with Rust 1.83,
-  // before AVX-512 intrinsics and target_feature were stabilized.
+  let mut output = std::mem::MaybeUninit::<[u64; 8]>::uninit();
+  // SAFETY: the caller proves AVX-512F/DQ support and that values points to
+  // eight readable u64 values. The unaligned store initializes exactly the
+  // eight output values; broadcasts read one seed and three constants. All
+  // used vector registers are declared clobbered. Assembly retains Rust 1.83
+  // compatibility, before AVX-512 intrinsics and target_feature stabilized.
+  // Every normal return follows the full 64-byte store, so assume_init is
+  // valid and avoids zeroing output that the assembly immediately replaces.
   unsafe {
     core::arch::asm!(
       "vmovdqu64 zmm0, [{values}]",
@@ -30,8 +36,9 @@ pub(super) unsafe fn splitmix64x8_avx512(values: &mut [u64; 8], seed: u64) {
       "vpmullq zmm0, zmm0, zmm1",
       "vpsrlq zmm2, zmm0, 31",
       "vpxorq zmm0, zmm0, zmm2",
-      "vmovdqu64 [{values}], zmm0",
-      values = in(reg) values.as_mut_ptr(),
+      "vmovdqu64 [{output}], zmm0",
+      values = in(reg) values,
+      output = in(reg) output.as_mut_ptr(),
       seed = in(reg) &raw const seed,
       constants = in(reg) CONSTANTS.as_ptr(),
       out("zmm0") _,
@@ -39,6 +46,7 @@ pub(super) unsafe fn splitmix64x8_avx512(values: &mut [u64; 8], seed: u64) {
       out("zmm2") _,
       options(nostack, preserves_flags),
     );
+    output.assume_init()
   }
 }
 
@@ -168,9 +176,8 @@ mod tests {
         .chain((0..128).map(|_| std::array::from_fn(|_| rng.next_u64())))
       {
         let expected = input.map(|value| scalar(value, seed));
-        let mut actual = input;
         // SAFETY: the test checked both required CPU/OS features above.
-        unsafe { splitmix64x8_avx512(&mut actual, seed) };
+        let actual = unsafe { splitmix64x8_avx512(input.as_ptr(), seed) };
         assert_eq!(actual, expected);
       }
     }

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -1,16 +1,17 @@
 use crate::utils::permute_hash;
 
+const SPLITMIX_CONSTANTS: [u64; 3] = [
+  0x9e37_79b9_7f4a_7c15,
+  0xbf58_476d_1ce4_e5b9,
+  0x94d0_49bb_1331_11eb,
+];
+
 /// Mixes eight independent token values; coordinate updates remain scalar.
 #[inline]
 pub(super) unsafe fn splitmix64x8_avx512(
   values: *const u64,
   seed: u64,
 ) -> [u64; 8] {
-  const CONSTANTS: [u64; 3] = [
-    0x9e37_79b9_7f4a_7c15,
-    0xbf58_476d_1ce4_e5b9,
-    0x94d0_49bb_1331_11eb,
-  ];
   let mut output = std::mem::MaybeUninit::<[u64; 8]>::uninit();
   // SAFETY: the caller proves AVX-512F/DQ support and that values points to
   // eight readable u64 values. The unaligned store initializes exactly the
@@ -40,7 +41,7 @@ pub(super) unsafe fn splitmix64x8_avx512(
       values = in(reg) values,
       output = in(reg) output.as_mut_ptr(),
       seed = in(reg) &raw const seed,
-      constants = in(reg) CONSTANTS.as_ptr(),
+      constants = in(reg) SPLITMIX_CONSTANTS.as_ptr(),
       out("zmm0") _,
       out("zmm1") _,
       out("zmm2") _,
@@ -60,11 +61,6 @@ pub(super) unsafe fn splitmix64x8_below_avx512<const RANK_SHIFT: u32>(
   bound: u32,
   output: &mut [u64; 8],
 ) -> u8 {
-  const CONSTANTS: [u64; 3] = [
-    0x9e37_79b9_7f4a_7c15,
-    0xbf58_476d_1ce4_e5b9,
-    0x94d0_49bb_1331_11eb,
-  ];
   const {
     assert!(RANK_SHIFT >= 33 && RANK_SHIFT < 64);
   }
@@ -102,7 +98,7 @@ pub(super) unsafe fn splitmix64x8_below_avx512<const RANK_SHIFT: u32>(
       "2:",
       values = in(reg) values,
       state = in(reg) state.as_ptr(),
-      constants = in(reg) CONSTANTS.as_ptr(),
+      constants = in(reg) SPLITMIX_CONSTANTS.as_ptr(),
       output = inout(reg) output.as_mut_ptr() => _,
       mask = lateout(reg) mask,
       rank_shift = const RANK_SHIFT,
@@ -132,11 +128,6 @@ pub(super) unsafe fn apply_buckets_below_avx512(
   bound: u32,
   hash_values: &mut [u32],
 ) -> usize {
-  const CONSTANTS: [u64; 3] = [
-    0x9e37_79b9_7f4a_7c15,
-    0xbf58_476d_1ce4_e5b9,
-    0x94d0_49bb_1331_11eb,
-  ];
   let Ok(width) = u32::try_from(hash_values.len()) else {
     return 0;
   };
@@ -198,7 +189,7 @@ pub(super) unsafe fn apply_buckets_below_avx512(
       "dec {count}",
       "jnz 2b",
       state = in(reg) state.as_ptr(),
-      constants = in(reg) CONSTANTS.as_ptr(),
+      constants = in(reg) SPLITMIX_CONSTANTS.as_ptr(),
       scratch = inout(reg) scratch.as_mut_ptr() => _,
       values = inout(reg) hash_values.as_mut_ptr() => _,
       cursor = inout(reg) input => _,

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -53,6 +53,7 @@ pub(super) unsafe fn splitmix64x8_avx512(
 /// Returns surviving lane positions, writing all mixed values to output only
 /// when at least one rank is below the supplied bound.
 #[inline]
+#[cfg(target_arch = "x86")]
 pub(super) unsafe fn splitmix64x8_below_avx512<const RANK_SHIFT: u32>(
   values: *const u64,
   seed: u64,
@@ -116,6 +117,109 @@ pub(super) unsafe fn splitmix64x8_below_avx512<const RANK_SHIFT: u32>(
   #[allow(clippy::cast_possible_truncation)]
   let mask = mask as u8;
   mask
+}
+
+/// Updates complete blocks of eight tokens below a fixed rank bound.
+/// Returns the consumed prefix length; the caller processes the tail in Rust.
+///
+/// # Safety
+/// AVX-512F/DQ must be available, and `input` must address `input_len` readable `u64` values.
+#[cfg(target_arch = "x86_64")]
+pub(super) unsafe fn apply_buckets_below_avx512(
+  input: *const u64,
+  input_len: usize,
+  seed: u64,
+  bound: u32,
+  hash_values: &mut [u32],
+) -> usize {
+  const CONSTANTS: [u64; 3] = [
+    0x9e37_79b9_7f4a_7c15,
+    0xbf58_476d_1ce4_e5b9,
+    0x94d0_49bb_1331_11eb,
+  ];
+  let Ok(width) = u32::try_from(hash_values.len()) else {
+    return 0;
+  };
+  let blocks = input_len / 8;
+  if !width.is_power_of_two() || blocks == 0 {
+    return 0;
+  }
+  let shift = 32 - width.trailing_zeros();
+  let state = [seed, u64::from(bound)];
+  let mut scratch = [0u64; 8];
+  // SAFETY: input supplies blocks * 8 tokens. The checked width is 2^p,
+  // p in 0..=31; zero-extending the low word and shifting by 32-p gives
+  // a valid coordinate, including width one. Every scratch read follows
+  // its complete 64-byte store, with a lane in 0..8 from the nonzero mask.
+  // Updates occur in lane order, so duplicate coordinates preserve minima.
+  // All modified registers and flags are declared. Constants remain live
+  // across the whole span, with no per-block stack state or broadcasts.
+  unsafe {
+    core::arch::asm!(
+      "vpbroadcastq zmm2, [{state}]",
+      "vpbroadcastq zmm3, [{constants}]",
+      "vpbroadcastq zmm4, [{constants} + 8]",
+      "vpbroadcastq zmm5, [{constants} + 16]",
+      "vpbroadcastq zmm6, [{state} + 8]",
+      "2:",
+      "vmovdqu64 zmm0, [{cursor}]",
+      "vpxorq zmm0, zmm0, zmm2",
+      "vpaddq zmm0, zmm0, zmm3",
+      "vpsrlq zmm1, zmm0, 30",
+      "vpxorq zmm0, zmm0, zmm1",
+      "vpmullq zmm0, zmm0, zmm4",
+      "vpsrlq zmm1, zmm0, 27",
+      "vpxorq zmm0, zmm0, zmm1",
+      "vpmullq zmm0, zmm0, zmm5",
+      // The final xor changes only bits 0..=32, leaving these ranks intact.
+      "vpsrlq zmm1, zmm0, 34",
+      "vpcmpuq k1, zmm1, zmm6, 1",
+      "kortestw k1, k1",
+      "jz 3f",
+      "vpsrlq zmm1, zmm0, 31",
+      "vpxorq zmm0, zmm0, zmm1",
+      "vmovdqu64 [{scratch}], zmm0",
+      "kmovw {mask:e}, k1",
+      "4:",
+      "bsf {lane:e}, {mask:e}",
+      "mov {mixed}, [{scratch} + {lane} * 8]",
+      "mov {bucket:e}, {mixed:e}",
+      "shr {bucket}, cl",
+      "shr {mixed}, 34",
+      "cmp dword ptr [{values} + {bucket} * 4], {mixed:e}",
+      "jbe 5f",
+      "mov dword ptr [{values} + {bucket} * 4], {mixed:e}",
+      "5:",
+      "lea {lane:e}, [{mask} - 1]",
+      "and {mask:e}, {lane:e}",
+      "jnz 4b",
+      "3:",
+      "add {cursor}, 64",
+      "dec {count}",
+      "jnz 2b",
+      state = in(reg) state.as_ptr(),
+      constants = in(reg) CONSTANTS.as_ptr(),
+      scratch = inout(reg) scratch.as_mut_ptr() => _,
+      values = inout(reg) hash_values.as_mut_ptr() => _,
+      cursor = inout(reg) input => _,
+      count = inout(reg) blocks => _,
+      inout("rcx") u64::from(shift) => _,
+      mask = lateout(reg) _,
+      lane = lateout(reg) _,
+      mixed = lateout(reg) _,
+      bucket = lateout(reg) _,
+      out("zmm0") _,
+      out("zmm1") _,
+      out("zmm2") _,
+      out("zmm3") _,
+      out("zmm4") _,
+      out("zmm5") _,
+      out("zmm6") _,
+      out("k1") _,
+      options(nostack),
+    );
+  }
+  blocks * 8
 }
 
 #[cfg(target_arch = "x86")]
@@ -252,6 +356,7 @@ mod tests {
   }
 
   #[test]
+  #[cfg(target_arch = "x86")]
   fn avx512_rank_mask_matches_scalar_at_exact_boundaries() {
     if !std::arch::is_x86_feature_detected!("avx512f")
       || !std::arch::is_x86_feature_detected!("avx512dq")
@@ -295,6 +400,85 @@ mod tests {
           };
           assert_eq!(actual, mask);
           assert_eq!(output, if mask == 0 { before } else { expected });
+        }
+      }
+    }
+  }
+  #[test]
+  #[cfg(target_arch = "x86_64")]
+  fn avx512_bucket_span_matches_scalar_with_bounds_tails_and_collisions() {
+    if !std::arch::is_x86_feature_detected!("avx512f")
+      || !std::arch::is_x86_feature_detected!("avx512dq")
+    {
+      return;
+    }
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x5350_414e);
+    let mut inputs = [0; 129];
+    for value in &mut inputs {
+      *value = rng.next_u64();
+    }
+    inputs[..8].copy_from_slice(&[
+      0,
+      1,
+      u64::MAX,
+      u64::MAX - 1,
+      1 << 31,
+      1 << 32,
+      1 << 63,
+      42,
+    ]);
+    for seed in [0, 42, u64::MAX] {
+      // Repeated tokens force colliding coordinates even with wide sketches.
+      for input in [&inputs, &[u64::MAX; 129]] {
+        let boundary = u32::try_from(scalar(input[0], seed) >> 34).unwrap();
+        for len in (0..=17).chain([31, 32, 33, 63, 64, 65, 128, 129]) {
+          for width in [0_usize, 1, 2, 3, 4, 8, 128, 129, 512] {
+            for bound in
+              [0, 1, 1 << 25, 1 << 30, u32::MAX, boundary, boundary + 1]
+            {
+              let mut actual: Vec<u32> = (0..width + 2)
+                .map(|index| match (index + len) % 4 {
+                  0 => u32::MAX,
+                  1 => 0,
+                  2 => 1,
+                  _ => rng.next_u32(),
+                })
+                .collect();
+              let mut expected = actual.clone();
+              let consumed = if width.is_power_of_two() {
+                len / 8 * 8
+              } else {
+                0
+              };
+              for &value in &input[..consumed] {
+                let mixed = scalar(value, seed);
+                let rank = u32::try_from(mixed >> 34).unwrap();
+                if rank < bound {
+                  // Product mapping is independent of the kernel's bit shift.
+                  let product = (mixed & u64::from(u32::MAX))
+                    * u64::try_from(width).unwrap();
+                  let bucket = usize::try_from(product >> 32).unwrap();
+                  expected[bucket + 1] = expected[bucket + 1].min(rank);
+                }
+              }
+              // SAFETY: features were checked, input covers len values and the
+              // output sub-slice includes exactly width initialized buckets.
+              let processed = unsafe {
+                crate::simd::x86::apply_buckets_below_avx512(
+                  input.as_ptr(),
+                  len,
+                  seed,
+                  bound,
+                  &mut actual[1..][..width],
+                )
+              };
+              assert_eq!(processed, consumed);
+              assert_eq!(
+                actual, expected,
+                "len={len}, width={width}, bound={bound}"
+              );
+            }
+          }
         }
       }
     }

--- a/src/simd/x86.rs
+++ b/src/simd/x86.rs
@@ -1,5 +1,47 @@
 use crate::utils::permute_hash;
 
+/// Mixes eight independent token values; coordinate updates remain scalar.
+#[inline]
+pub(super) unsafe fn splitmix64x8_avx512(values: &mut [u64; 8], seed: u64) {
+  const CONSTANTS: [u64; 3] = [
+    0x9e37_79b9_7f4a_7c15,
+    0xbf58_476d_1ce4_e5b9,
+    0x94d0_49bb_1331_11eb,
+  ];
+  // SAFETY: the caller proves AVX-512F/DQ support. The unaligned load/store
+  // access exactly the initialized, exclusively borrowed eight-value array;
+  // broadcasts read one seed and three constants. All used vector registers
+  // are declared clobbered. Assembly retains compatibility with Rust 1.83,
+  // before AVX-512 intrinsics and target_feature were stabilized.
+  unsafe {
+    core::arch::asm!(
+      "vmovdqu64 zmm0, [{values}]",
+      "vpbroadcastq zmm1, [{seed}]",
+      "vpxorq zmm0, zmm0, zmm1",
+      "vpbroadcastq zmm1, [{constants}]",
+      "vpaddq zmm0, zmm0, zmm1",
+      "vpsrlq zmm2, zmm0, 30",
+      "vpxorq zmm0, zmm0, zmm2",
+      "vpbroadcastq zmm1, [{constants} + 8]",
+      "vpmullq zmm0, zmm0, zmm1",
+      "vpsrlq zmm2, zmm0, 27",
+      "vpxorq zmm0, zmm0, zmm2",
+      "vpbroadcastq zmm1, [{constants} + 16]",
+      "vpmullq zmm0, zmm0, zmm1",
+      "vpsrlq zmm2, zmm0, 31",
+      "vpxorq zmm0, zmm0, zmm2",
+      "vmovdqu64 [{values}], zmm0",
+      values = in(reg) values.as_mut_ptr(),
+      seed = in(reg) &raw const seed,
+      constants = in(reg) CONSTANTS.as_ptr(),
+      out("zmm0") _,
+      out("zmm1") _,
+      out("zmm2") _,
+      options(nostack, preserves_flags),
+    );
+  }
+}
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
   __m256i, _mm256_loadu_si256, _mm256_min_epu32, _mm256_storeu_si256,
@@ -87,4 +129,50 @@ unsafe fn load_u32x8(ptr: *const u32) -> __m256i {
 unsafe fn store_u32x8(ptr: *mut u32, value: __m256i) {
   // SAFETY: caller guarantees `ptr` is valid for 8 contiguous mutable `u32` values.
   unsafe { _mm256_storeu_si256(ptr.cast::<__m256i>(), value) };
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::simd::x86::splitmix64x8_avx512;
+  use rand_core::{RngCore, SeedableRng};
+  use rand_xoshiro::Xoshiro256PlusPlus;
+
+  fn scalar(mut value: u64, seed: u64) -> u64 {
+    value = (value ^ seed).wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+  }
+
+  #[test]
+  fn avx512_mixer_matches_wrapping_scalar_for_every_lane() {
+    if !std::arch::is_x86_feature_detected!("avx512f")
+      || !std::arch::is_x86_feature_detected!("avx512dq")
+    {
+      return;
+    }
+    let edges = [
+      0,
+      1,
+      u64::MAX,
+      u64::MAX - 1,
+      u64::from(u32::MAX),
+      1 << 32,
+      1 << 63,
+      0xaaaa_aaaa_5555_5555,
+    ];
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x4156_5835_3132);
+    for seed in [0, 1, 42, u64::MAX, rng.next_u64()] {
+      for input in std::iter::once(edges)
+        .chain(edges.map(|value| [value; 8]))
+        .chain((0..128).map(|_| std::array::from_fn(|_| rng.next_u64())))
+      {
+        let expected = input.map(|value| scalar(value, seed));
+        let mut actual = input;
+        // SAFETY: the test checked both required CPU/OS features above.
+        unsafe { splitmix64x8_avx512(&mut actual, seed) };
+        assert_eq!(actual, expected);
+      }
+    }
+  }
 }

--- a/src/simd/x86_avx512.rs
+++ b/src/simd/x86_avx512.rs
@@ -77,9 +77,87 @@ pub(super) unsafe fn apply_hash_batch_to_values_avx512(
   }
 }
 
+/// Updates only fallback coordinates, mixing eight tokens per vector.
+///
+/// # Safety
+/// The caller must establish AVX-512F and AVX-512DQ CPU/OS support.
+pub(super) unsafe fn apply_bucket_fallback_avx512(
+  hash_values: &mut [u32],
+  permutations: &[(u64, u64)],
+  hashes: &[u64],
+  rank_bits: u32,
+) {
+  debug_assert!((1..32).contains(&rank_bits));
+  let fallback = u32::MAX << (32 - rank_bits);
+  let discarded = (1 << rank_bits) - 1;
+  let blocks = hashes.len() / 8;
+  let tail = &hashes[blocks * 8..];
+
+  for (value, (a, b)) in hash_values.iter_mut().zip(permutations) {
+    if *value < fallback {
+      continue;
+    }
+    // Recover the greatest raw rank represented by the stored fraction.
+    let mut minimum = (*value << rank_bits) | discarded;
+    if blocks != 0 {
+      // SAFETY: the caller proves AVX-512F/DQ support. Broadcasts read the
+      // initialized a/b scalars and four-byte minimum. The token loop reads
+      // blocks * 8 initialized hashes. The final store writes only minimum.
+      // All modified registers are declared, including flags via omission
+      // of preserves_flags. No target_feature or AVX-512 intrinsics are
+      // needed, retaining Rust 1.83 compatibility.
+      unsafe {
+        core::arch::asm!(
+          "vpbroadcastq zmm0, [{a}]",
+          "vpbroadcastq zmm1, [{b}]",
+          "vpbroadcastd zmm2, [{minimum}]",
+          "vpsrlq zmm2, zmm2, 32",
+          "2:",
+          "vmovdqu64 zmm3, [{cursor}]",
+          "vpmullq zmm3, zmm3, zmm0",
+          "vpaddq zmm3, zmm3, zmm1",
+          "vpsrlq zmm3, zmm3, 32",
+          "vpminuq zmm2, zmm2, zmm3",
+          "add {cursor}, 64",
+          "dec {count}",
+          "jnz 2b",
+          // Reduce all eight u64 lanes: halves, 128-bit pairs, then neighbors.
+          "vshufi64x2 zmm3, zmm2, zmm2, 0x4e",
+          "vpminuq zmm2, zmm2, zmm3",
+          "vshufi64x2 zmm3, zmm2, zmm2, 0xb1",
+          "vpminuq zmm2, zmm2, zmm3",
+          "vpshufd zmm3, zmm2, 0x4e",
+          "vpminuq zmm2, zmm2, zmm3",
+          "vmovd [{minimum}], xmm2",
+          a = in(reg) a,
+          b = in(reg) b,
+          minimum = in(reg) &raw mut minimum,
+          cursor = inout(reg) hashes.as_ptr() => _,
+          count = inout(reg) blocks => _,
+          out("zmm0") _,
+          out("zmm1") _,
+          out("zmm2") _,
+          out("zmm3") _,
+          options(nostack),
+        );
+      }
+    }
+    // Zero is final; the early exit also keeps this short tail scalar.
+    for &hash in tail {
+      if minimum == 0 {
+        break;
+      }
+      minimum = minimum.min(permute_hash(hash, *a, *b));
+    }
+    *value = fallback | (minimum >> rank_bits);
+  }
+}
+
 #[cfg(test)]
 mod tests {
-  use crate::simd::x86_avx512::apply_hash_batch_to_values_avx512;
+  use crate::simd::x86_avx512::{
+    apply_bucket_fallback_avx512, apply_hash_batch_to_values_avx512,
+  };
   use rand_core::{RngCore, SeedableRng};
   use rand_xoshiro::Xoshiro256PlusPlus;
 
@@ -159,6 +237,89 @@ mod tests {
             );
           }
           assert_eq!(actual, expected, "width={width}, hashes={hash_len}");
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn avx512_bucket_fallback_reduces_every_vector_lane() {
+    if !supported() {
+      return;
+    }
+    for lane in 0..8 {
+      let mut hashes = [u64::MAX; 40];
+      hashes[8 + lane] = 0;
+      let mut values = [u32::MAX];
+      // SAFETY: both required CPU/OS features were detected above.
+      unsafe {
+        apply_bucket_fallback_avx512(&mut values, &[(1, 0)], &hashes, 2);
+      }
+      assert_eq!(values, [0xc000_0000], "minimum in lane {lane}");
+    }
+  }
+
+  #[test]
+  fn avx512_bucket_fallback_matches_scalar_at_boundaries_and_tails() {
+    if !supported() {
+      return;
+    }
+    let edges = [
+      0,
+      1,
+      u64::MAX,
+      u64::MAX - 1,
+      u64::from(u32::MAX),
+      1 << 32,
+      1 << 63,
+    ];
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(42);
+    for width in [0, 1, 3, 7, 8, 9, 31, 32, 33, 127, 128, 129, 511, 512] {
+      let permutations: Vec<_> = (0..width)
+        .map(|lane| {
+          if lane < edges.len() {
+            (edges[lane], edges[edges.len() - lane - 1])
+          } else {
+            (rng.next_u64(), rng.next_u64())
+          }
+        })
+        .collect();
+      for hash_len in [0, 1, 7, 8, 9, 31, 32, 33, 39, 40, 127, 128, 129] {
+        let hashes: Vec<_> = (0..hash_len)
+          .map(|lane| {
+            if lane < edges.len() {
+              edges[lane]
+            } else {
+              rng.next_u64()
+            }
+          })
+          .collect();
+        for rank_bits in [1, 2, 8, 31] {
+          let fallback = u32::MAX << (32 - rank_bits);
+          let boundaries = [0, fallback - 1, fallback, fallback + 1, u32::MAX];
+          let mut actual: Vec<_> = (0..width + 3)
+            .map(|lane| boundaries[lane % boundaries.len()])
+            .collect();
+          let mut expected = actual.clone();
+          for (value, &(a, b)) in expected[1..].iter_mut().zip(&permutations) {
+            for &hash in &hashes {
+              *value =
+                (*value).min(fallback | (reference(hash, a, b) >> rank_bits));
+            }
+          }
+          // SAFETY: both required CPU/OS features were detected above.
+          unsafe {
+            apply_bucket_fallback_avx512(
+              &mut actual[1..],
+              &permutations,
+              &hashes,
+              rank_bits,
+            );
+          }
+          assert_eq!(
+            actual, expected,
+            "width={width}, hashes={hash_len}, rank_bits={rank_bits}"
+          );
         }
       }
     }

--- a/src/simd/x86_avx512.rs
+++ b/src/simd/x86_avx512.rs
@@ -1,5 +1,13 @@
 use crate::utils::permute_hash;
 
+// The direct loads below consume the tuple's actual in-memory field order.
+const _: () = assert!(std::mem::size_of::<(u64, u64)>() == 16);
+const _: () = assert!(std::mem::offset_of!((u64, u64), 0) == 0);
+const _: () = assert!(std::mem::offset_of!((u64, u64), 1) == 8);
+
+const COEFFICIENT_INDICES: [[u64; 8]; 2] =
+  [[0, 2, 4, 6, 8, 10, 12, 14], [1, 3, 5, 7, 9, 11, 13, 15]];
+
 /// Applies eight affine permutations at a time, retaining their coefficients
 /// and minima in registers across the token batch.
 ///
@@ -18,18 +26,21 @@ pub(super) unsafe fn apply_hash_batch_to_values_avx512(
   let mut value_chunks = hash_values[..perm_len].chunks_exact_mut(8);
   let mut perm_chunks = permutations[..perm_len].chunks_exact(8);
   for (values, perms) in value_chunks.by_ref().zip(perm_chunks.by_ref()) {
-    let a: [u64; 8] = std::array::from_fn(|lane| perms[lane].0);
-    let b: [u64; 8] = std::array::from_fn(|lane| perms[lane].1);
-    // SAFETY: the caller establishes AVX-512F/DQ support. Each coefficient
-    // array supplies 64 readable bytes, and values supplies 32 readable and
-    // writable bytes. The nonempty token slice supplies exactly count reads
-    // of 8 bytes. Every vector register and modified GPR is declared below.
+    // SAFETY: the caller establishes AVX-512F/DQ support. The
+    // coefficient chunk supplies 128 readable bytes with the tuple layout
+    // checked above; indices supply 128 readable bytes. The values chunk
+    // supplies 32 readable/writable bytes. The nonempty token slice supplies
+    // exactly count reads of 8 bytes. All modified registers are declared.
     // Inline assembly keeps this kernel compatible with Rust 1.83, before
     // AVX-512 intrinsics and target_feature were stabilized.
     unsafe {
       core::arch::asm!(
-        "vmovdqu64 zmm0, [{a}]",
-        "vmovdqu64 zmm1, [{b}]",
+        "vmovdqu64 zmm2, [{perms}]",
+        "vmovdqu64 zmm3, [{perms} + 64]",
+        "vmovdqu64 zmm0, [{indices}]",
+        "vmovdqu64 zmm1, [{indices} + 64]",
+        "vpermi2q zmm0, zmm2, zmm3",
+        "vpermi2q zmm1, zmm2, zmm3",
         "vpmovzxdq zmm2, ymmword ptr [{values}]",
         "2:",
         "vpbroadcastq zmm3, [{cursor}]",
@@ -41,8 +52,8 @@ pub(super) unsafe fn apply_hash_batch_to_values_avx512(
         "dec {count}",
         "jnz 2b",
         "vpmovqd ymmword ptr [{values}], zmm2",
-        a = in(reg) a.as_ptr(),
-        b = in(reg) b.as_ptr(),
+        perms = in(reg) perms.as_ptr(),
+        indices = in(reg) COEFFICIENT_INDICES.as_ptr(),
         values = in(reg) values.as_mut_ptr(),
         cursor = inout(reg) hash_batch.as_ptr() => _,
         count = inout(reg) hash_batch.len() => _,

--- a/src/simd/x86_avx512.rs
+++ b/src/simd/x86_avx512.rs
@@ -1,0 +1,155 @@
+use crate::utils::permute_hash;
+
+/// Applies eight affine permutations at a time, retaining their coefficients
+/// and minima in registers across the token batch.
+///
+/// # Safety
+/// The caller must establish AVX-512F and AVX-512DQ CPU/OS support.
+pub(super) unsafe fn apply_hash_batch_to_values_avx512(
+  hash_values: &mut [u32],
+  permutations: &[(u64, u64)],
+  hash_batch: &[u64],
+) {
+  let perm_len = hash_values.len().min(permutations.len());
+  if perm_len == 0 || hash_batch.is_empty() {
+    return;
+  }
+
+  let mut value_chunks = hash_values[..perm_len].chunks_exact_mut(8);
+  let mut perm_chunks = permutations[..perm_len].chunks_exact(8);
+  for (values, perms) in value_chunks.by_ref().zip(perm_chunks.by_ref()) {
+    let a: [u64; 8] = std::array::from_fn(|lane| perms[lane].0);
+    let b: [u64; 8] = std::array::from_fn(|lane| perms[lane].1);
+    // SAFETY: the caller establishes AVX-512F/DQ support. Each coefficient
+    // array supplies 64 readable bytes, and values supplies 32 readable and
+    // writable bytes. The nonempty token slice supplies exactly count reads
+    // of 8 bytes. Every vector register and modified GPR is declared below.
+    // Inline assembly keeps this kernel compatible with Rust 1.83, before
+    // AVX-512 intrinsics and target_feature were stabilized.
+    unsafe {
+      core::arch::asm!(
+        "vmovdqu64 zmm0, [{a}]",
+        "vmovdqu64 zmm1, [{b}]",
+        "vpmovzxdq zmm2, ymmword ptr [{values}]",
+        "2:",
+        "vpbroadcastq zmm3, [{cursor}]",
+        "vpmullq zmm3, zmm3, zmm0",
+        "vpaddq zmm3, zmm3, zmm1",
+        "vpsrlq zmm3, zmm3, 32",
+        "vpminuq zmm2, zmm2, zmm3",
+        "add {cursor}, 8",
+        "dec {count}",
+        "jnz 2b",
+        "vpmovqd ymmword ptr [{values}], zmm2",
+        a = in(reg) a.as_ptr(),
+        b = in(reg) b.as_ptr(),
+        values = in(reg) values.as_mut_ptr(),
+        cursor = inout(reg) hash_batch.as_ptr() => _,
+        count = inout(reg) hash_batch.len() => _,
+        out("zmm0") _,
+        out("zmm1") _,
+        out("zmm2") _,
+        out("zmm3") _,
+        options(nostack),
+      );
+    }
+  }
+
+  for (value, &(a, b)) in value_chunks
+    .into_remainder()
+    .iter_mut()
+    .zip(perm_chunks.remainder())
+  {
+    for &hash in hash_batch {
+      *value = (*value).min(permute_hash(hash, a, b));
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::simd::x86_avx512::apply_hash_batch_to_values_avx512;
+  use rand_core::{RngCore, SeedableRng};
+  use rand_xoshiro::Xoshiro256PlusPlus;
+
+  fn supported() -> bool {
+    std::arch::is_x86_feature_detected!("avx512f")
+      && std::arch::is_x86_feature_detected!("avx512dq")
+  }
+
+  fn reference(hash: u64, a: u64, b: u64) -> u32 {
+    let product = u128::from(hash) * u128::from(a) + u128::from(b);
+    u32::try_from((product >> 32) & u128::from(u32::MAX)).unwrap()
+  }
+
+  #[test]
+  fn avx512_affine_preserves_full_width_carries_and_overflow() {
+    if !supported() {
+      return;
+    }
+    let edges = [
+      0,
+      1,
+      u64::MAX,
+      u64::MAX - 1,
+      u64::from(u32::MAX),
+      1 << 32,
+      1 << 63,
+      0xaaaa_aaaa_5555_5555,
+    ];
+    for &hash in &edges {
+      for &a in &edges {
+        let permutations = edges.map(|b| (a, b));
+        let mut values = [u32::MAX; 8];
+        let expected = edges.map(|b| reference(hash, a, b));
+        // SAFETY: both required CPU/OS features were detected above.
+        unsafe {
+          apply_hash_batch_to_values_avx512(
+            &mut values,
+            &permutations,
+            &[hash],
+          );
+        }
+        assert_eq!(values, expected, "hash={hash}, a={a}");
+      }
+    }
+  }
+
+  #[test]
+  fn avx512_affine_matches_scalar_for_tails_empty_and_existing_minima() {
+    if !supported() {
+      return;
+    }
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x4156_5835_3132);
+    for width in (0..=33).chain([63, 64, 65, 127, 128, 129, 511, 512]) {
+      let permutations: Vec<_> = (0..width)
+        .map(|_| (rng.next_u64(), rng.next_u64()))
+        .collect();
+      for hash_len in [0, 1, 2, 7, 8, 9, 31, 32, 129] {
+        let hashes: Vec<_> = (0..hash_len).map(|_| rng.next_u64()).collect();
+        for populated in [false, true] {
+          let mut actual: Vec<_> = (0..width + 3)
+            .map(|_| if populated { rng.next_u32() } else { u32::MAX })
+            .collect();
+          let mut expected = actual.clone();
+          // Offset the mutable view and leave extra lanes without coefficients.
+          // The kernel must preserve both those lanes and the outer sentinels.
+          for (value, &(a, b)) in expected[1..].iter_mut().zip(&permutations) {
+            for &hash in &hashes {
+              *value = (*value).min(reference(hash, a, b));
+            }
+          }
+          // SAFETY: both required CPU/OS features were detected above.
+          unsafe {
+            apply_hash_batch_to_values_avx512(
+              &mut actual[1..],
+              &permutations,
+              &hashes,
+            );
+          }
+          assert_eq!(actual, expected, "width={width}, hashes={hash_len}");
+        }
+      }
+    }
+  }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -101,19 +101,9 @@ const fn hash_add_u32(hash: usize, value: u32) -> usize {
 }
 
 #[inline]
-pub fn usize_to_f64(value: usize) -> f64 {
-  #[cfg(target_pointer_width = "64")]
-  {
-    let bytes = value.to_be_bytes();
-    let high = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-    let low = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
-    f64::from(high).mul_add(4_294_967_296.0, f64::from(low))
-  }
-
-  #[cfg(target_pointer_width = "32")]
-  {
-    f64::from(u32::from_ne_bytes(value.to_ne_bytes()))
-  }
+#[allow(clippy::cast_precision_loss)]
+pub const fn usize_to_f64(value: usize) -> f64 {
+  value as f64
 }
 
 #[inline]
@@ -212,14 +202,7 @@ pub fn calculate_band_hash(band: &[u32]) -> u64 {
     hash = hash_add_u32(hash, value);
   }
 
-  #[cfg(target_pointer_width = "64")]
-  {
-    hash.rotate_left(ROTATE) as u64
-  }
-  #[cfg(target_pointer_width = "32")]
-  {
-    hash.rotate_left(ROTATE) as u64
-  }
+  hash.rotate_left(ROTATE) as u64
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,27 +17,17 @@ const SEED2: u64 = 0x1319_8a2e_0370_7344;
 const PREVENT_TRIVIAL_ZERO_COLLAPSE: u64 = 0xa409_3822_299f_31d0;
 
 #[inline]
-const fn read_u64_le(bytes: &[u8], offset: usize) -> u64 {
-  u64::from_le_bytes([
-    bytes[offset],
-    bytes[offset + 1],
-    bytes[offset + 2],
-    bytes[offset + 3],
-    bytes[offset + 4],
-    bytes[offset + 5],
-    bytes[offset + 6],
-    bytes[offset + 7],
-  ])
+fn read_u64_le(bytes: &[u8], offset: usize) -> u64 {
+  let mut word = [0; 8];
+  word.copy_from_slice(&bytes[offset..offset + 8]);
+  u64::from_le_bytes(word)
 }
 
 #[inline]
-const fn read_u32_le(bytes: &[u8], offset: usize) -> u32 {
-  u32::from_le_bytes([
-    bytes[offset],
-    bytes[offset + 1],
-    bytes[offset + 2],
-    bytes[offset + 3],
-  ])
+fn read_u32_le(bytes: &[u8], offset: usize) -> u32 {
+  let mut word = [0; 4];
+  word.copy_from_slice(&bytes[offset..offset + 4]);
+  u32::from_le_bytes(word)
 }
 
 #[cfg(target_pointer_width = "32")]
@@ -251,6 +241,17 @@ mod tests {
 
     for bytes in data {
       assert_eq!(calculate_hash_fast(bytes), reference_hash_fast(bytes));
+    }
+  }
+
+  #[test]
+  fn calculate_hash_fast_matches_reference_for_lengths_and_alignments() {
+    let bytes: Vec<u8> = (0u8..=255).cycle().take(272).collect();
+    for offset in 0..16 {
+      for length in 0..=256 {
+        let input = &bytes[offset..offset + length];
+        assert_eq!(calculate_hash_fast(input), reference_hash_fast(input));
+      }
     }
   }
 

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,0 +1,76 @@
+"""Accuracy against exact sets and signature invariants across kernel tails."""
+
+import pytest
+
+from rensa import CMinHash, RMinHash
+
+
+@pytest.mark.parametrize("minhash_type", [RMinHash, CMinHash])
+@pytest.mark.parametrize("num_perm", [1, 7, 17, 63, 129])
+def test_signature_is_invariant_to_order_duplicates_and_update_boundaries(
+    minhash_type, num_perm
+):
+    tokens = [f"token-{index}" for index in range(97)]
+    tokens += ["", "café", "飛行機", "a" * 129]
+    expected = minhash_type(num_perm=num_perm, seed=42)
+    expected.update(tokens)
+
+    reordered = minhash_type(num_perm=num_perm, seed=42)
+    reordered.update(list(reversed(tokens)) * 3)
+    incremental = minhash_type(num_perm=num_perm, seed=42)
+    # Cross both the 32-token batching boundary and SIMD remainder lanes.
+    for start, end in [(0, 1), (1, 32), (32, 33), (33, 65), (65, len(tokens))]:
+        incremental.update(tokens[start:end])
+    incremental.update([])
+    incremental.update(tokens[:7])
+
+    digest = "digest_u64" if minhash_type is CMinHash else "digest"
+    assert getattr(reordered, digest)() == getattr(expected, digest)()
+    assert getattr(incremental, digest)() == getattr(expected, digest)()
+    assert expected.jaccard(reordered) == 1.0
+
+
+@pytest.mark.parametrize("minhash_type", [RMinHash, CMinHash])
+@pytest.mark.parametrize("overlap", [0, 32, 64, 85, 96])
+def test_mean_jaccard_tracks_exact_set_similarity(minhash_type, overlap):
+    left_tokens = [f"token-{index}" for index in range(96)]
+    right_tokens = left_tokens[:overlap] + [
+        f"other-{index}" for index in range(96 - overlap)
+    ]
+    left_set, right_set = set(left_tokens), set(right_tokens)
+    exact = len(left_set & right_set) / len(left_set | right_set)
+    estimates = []
+    # Fixed independent seeds make this a reproducible aggregate accuracy check,
+    # not a requirement that a single probabilistic sketch equal the ground truth.
+    for seed in range(32):
+        left = minhash_type(num_perm=256, seed=seed)
+        right = minhash_type(num_perm=256, seed=seed)
+        left.update(left_tokens)
+        right.update(right_tokens)
+        estimates.append(left.jaccard(right))
+    assert abs(sum(estimates) / len(estimates) - exact) < 0.06
+
+
+@pytest.mark.parametrize("minhash_type", [RMinHash, CMinHash])
+def test_empty_signature_similarity(minhash_type):
+    empty = minhash_type(num_perm=129, seed=42)
+    other_empty = minhash_type(num_perm=129, seed=42)
+    populated = minhash_type(num_perm=129, seed=42)
+    populated.update(["nonempty"])
+    assert empty.jaccard(other_empty) == 1.0
+    assert empty.jaccard(populated) == 0.0
+
+
+def test_rho_empty_identical_and_disjoint_sets():
+    # Short documents use every token, avoiding the intentional position-based
+    # sampling of longer documents when testing exact endpoint behavior.
+    left = [f"left-{index}" for index in range(24)]
+    right = [f"right-{index}" for index in range(24)]
+    rows = RMinHash.digest_matrix_from_token_sets_rho(
+        [[], [], left, left, right], num_perm=129, seed=42
+    ).to_rows()
+    assert rows[0] == rows[1] == [2**32 - 1] * 129
+    assert rows[2] == rows[3]
+    assert any(value != 2**32 - 1 for value in rows[2])
+    # Matching empty buckets are not evidence that the source sets overlap.
+    assert all(a != b or a == 2**32 - 1 for a, b in zip(rows[2], rows[4]))

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -74,3 +74,18 @@ def test_rho_empty_identical_and_disjoint_sets():
     assert any(value != 2**32 - 1 for value in rows[2])
     # Matching empty buckets are not evidence that the source sets overlap.
     assert all(a != b or a == 2**32 - 1 for a, b in zip(rows[2], rows[4]))
+
+
+@pytest.mark.parametrize("queue_capacity", [0, 2])
+@pytest.mark.parametrize("streaming", [False, True])
+def test_batch_chunk_reuse_preserves_each_signature(monkeypatch, queue_capacity, streaming):
+    monkeypatch.setenv("RENSA_DOC_CHUNK_SIZE", "256")
+    monkeypatch.setenv("RENSA_PIPELINE_QUEUE_CAP", str(queue_capacity))
+    documents = [[f"row-{row}", f"group-{row % 7}"] for row in range(600)]
+    expected = []
+    for tokens in documents:
+        sketch = RMinHash(num_perm=17, seed=42)
+        sketch.update(tokens)
+        expected.append(sketch.digest())
+    source = (tokens for tokens in documents) if streaming else documents
+    assert RMinHash.digest_matrix_from_token_sets(source, 17, 42).to_rows() == expected

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,5 +1,8 @@
 """Accuracy against exact sets and signature invariants across kernel tails."""
 
+import math
+import statistics
+
 import pytest
 
 from rensa import CMinHash, RMinHash
@@ -49,6 +52,32 @@ def test_mean_jaccard_tracks_exact_set_similarity(minhash_type, overlap):
         right.update(right_tokens)
         estimates.append(left.jaccard(right))
     assert abs(sum(estimates) / len(estimates) - exact) < 0.06
+
+
+@pytest.mark.parametrize("prehashed", [False, True])
+def test_cminhash_jaccard_error_reduces_with_more_permutations(prehashed):
+    # Two-element sets expose correlated permutation lanes that a mean-only
+    # check on larger sets misses. Sequential hashes also exercise structured
+    # input without relying on the string hash to supply the initial shuffle.
+    rows = [[0, 1], [1, 2]] if prehashed else [["left", "shared"], ["shared", "right"]]
+    digest = (
+        CMinHash.digests64_from_token_hash_sets
+        if prehashed
+        else CMinHash.digests64_from_token_sets
+    )
+    exact = 1 / 3
+    errors_by_width = {}
+    for num_perm in (128, 512):
+        errors = []
+        for seed in range(96):
+            left, right = digest(rows, num_perm=num_perm, seed=seed)
+            estimate = sum(a == b for a, b in zip(left, right)) / num_perm
+            errors.append(estimate - exact)
+        assert abs(statistics.mean(errors)) < 0.02
+        errors_by_width[num_perm] = math.sqrt(statistics.mean(error**2 for error in errors))
+    assert errors_by_width[128] < 0.07
+    assert errors_by_width[512] < 0.04
+    assert errors_by_width[512] < 0.75 * errors_by_width[128]
 
 
 @pytest.mark.parametrize("minhash_type", [RMinHash, CMinHash])

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -5,7 +5,7 @@ import statistics
 
 import pytest
 
-from rensa import CMinHash, RMinHash
+from rensa import CMinHash, RMinHash, RMinHashLSH
 
 
 @pytest.mark.parametrize("minhash_type", [RMinHash, CMinHash])
@@ -78,6 +78,95 @@ def test_cminhash_jaccard_error_reduces_with_more_permutations(prehashed):
     assert errors_by_width[128] < 0.07
     assert errors_by_width[512] < 0.04
     assert errors_by_width[512] < 0.75 * errors_by_width[128]
+
+
+@pytest.mark.parametrize(
+    "prehashed,left_size,right_size,overlap",
+    [
+        (False, 2, 2, 1),
+        (True, 2, 2, 1),
+        (False, 16, 1024, 16),
+        (True, 64, 1024, 64),
+        (False, 128, 160, 128),
+        (False, 1024, 1280, 1024),
+        (False, 2048, 3072, 1536),
+    ],
+)
+def test_rminhash_accuracy_across_cardinalities(
+    prehashed, left_size, right_size, overlap
+):
+    left = list(range(left_size))
+    right = left[left_size - overlap:] + list(
+        range(left_size, left_size + right_size - overlap)
+    )
+    rows = [left, right]
+    if not prehashed:
+        rows = [[f"cardinality-token-{value}" for value in row] for row in rows]
+    digest = (
+        RMinHash.digest_matrix_from_token_hash_sets
+        if prehashed
+        else RMinHash.digest_matrix_from_token_sets
+    )
+    exact = overlap / (left_size + right_size - overlap)
+    mse_by_width = {}
+    seed_count = 96
+    for num_perm in (128, 512):
+        errors = []
+        for seed in range(seed_count):
+            first, second = digest(rows, num_perm=num_perm, seed=seed).to_rows()
+            estimate = sum(a == b for a, b in zip(first, second)) / num_perm
+            errors.append(estimate - exact)
+        # Compare aggregate error with classical independent MinHash variance.
+        # The allowance covers finite fixed-seed sampling, not a changed target.
+        reference_variance = exact * (1 - exact) / num_perm
+        assert abs(statistics.mean(errors)) < 4 * math.sqrt(reference_variance / seed_count)
+        mse_by_width[num_perm] = statistics.mean(error**2 for error in errors)
+        assert mse_by_width[num_perm] < 1.65 * reference_variance
+    assert mse_by_width[512] < 0.6 * mse_by_width[128]
+
+
+@pytest.mark.parametrize("num_perm", [128, 129])
+def test_rminhash_long_sets_preserve_order_duplicates_and_incremental_updates(num_perm):
+    tokens = [f"long-token-{index}" for index in range(8193)]
+    rows = RMinHash.digest_matrix_from_token_sets(
+        [tokens, list(reversed(tokens)), tokens * 2], num_perm=num_perm, seed=42
+    ).to_rows()
+    assert rows[0] == rows[1] == rows[2]
+    for chunk_size in (1, 31, 257, len(tokens)):
+        incremental = RMinHash(num_perm=num_perm, seed=42)
+        for start in range(0, len(tokens), chunk_size):
+            incremental.update(tokens[start:start + chunk_size])
+        incremental.update([])
+        incremental.update(tokens[::3])
+        assert incremental.digest() == rows[0]
+
+
+def test_rminhash_batch_and_object_queries_agree_across_document_sizes():
+    short = [f"short-{index}" for index in range(128)]
+    long = [f"long-{index}" for index in range(2048)]
+    documents = [
+        short,
+        short + [f"short-extra-{index}" for index in range(32)],
+        long,
+        long + [f"long-extra-{index}" for index in range(512)],
+        list(reversed(long)),
+        ["unrelated"],
+    ]
+    signatures = RMinHash.from_token_sets(documents, num_perm=128, seed=42)
+    matrix = RMinHash.digest_matrix_from_token_sets(documents, num_perm=128, seed=42)
+    index = RMinHashLSH(threshold=0.8, num_perm=128, num_bands=8)
+    for key, signature in enumerate(signatures):
+        index.insert(key, signature)
+    expected = [
+        any(candidate != key for candidate in index.query(signature))
+        for key, signature in enumerate(signatures)
+    ]
+    batch_index = RMinHashLSH(threshold=0.8, num_perm=128, num_bands=8)
+    assert batch_index.query_duplicate_flags_matrix_one_shot(matrix) == expected
+    assert expected[2] and expected[4]
+    assert not expected[5]
+    for left, right in [(signatures[0], signatures[1]), (signatures[2], signatures[3])]:
+        assert index.is_similar(left, right) == (left.jaccard(right) >= 0.8)
 
 
 @pytest.mark.parametrize("minhash_type", [RMinHash, CMinHash])

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -11,6 +11,36 @@ from pathlib import Path
 import pytest
 
 
+@pytest.mark.skipif(
+    sys.implementation.name != "cpython", reason="Requires CPython reference counting"
+)
+def test_kernel_measure_destroys_results_outside_timed_intervals(monkeypatch):
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "benchmarks"))
+    benchmark = importlib.import_module("kernel_benchmark")
+    events = []
+    ticks = iter(range(8))
+
+    class Result:
+        def __init__(self):
+            events.append("create")
+
+        def __del__(self):
+            events.append("destroy")
+
+    def clock():
+        tick = next(ticks)
+        events.append("start" if tick % 2 == 0 else "stop")
+        return tick * 1_000_000_000
+
+    monkeypatch.setattr(benchmark.time, "perf_counter", lambda: 0)
+    monkeypatch.setattr(benchmark.time, "perf_counter_ns", clock)
+    result = benchmark.measure(Result, lambda result: [1], 2, 2, 0)
+
+    assert result["iterations"] == [2, 2]
+    assert result["seconds"] == [1.0, 1.0]
+    assert events == ["create", "destroy"] + ["start", "create", "stop", "destroy"] * 4
+
+
 @pytest.mark.parametrize("module_name", ["simple_benchmark", "full_benchmark"])
 def test_benchmark_records_order_sensitive_duplicate_decisions(
     module_name, monkeypatch, tmp_path, capsys

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -3,6 +3,9 @@ import hashlib
 import importlib
 import json
 import pickle
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -61,3 +64,95 @@ def test_installed_fastsketch_detects_exact_duplicates(monkeypatch):
     assert flags == [True, False, True]
     assert metrics["rows_removed"] == 2
     assert metrics["rows_remaining"] == 1
+
+
+@pytest.fixture
+def paired_benchmark(monkeypatch):
+    pytest.importorskip("FastSketchLSH")
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "benchmarks"))
+    return importlib.import_module("paired_sketch_benchmark")
+
+
+@pytest.mark.parametrize("mode", [[], ["--prehashed"], ["--prehashed", "--repeat-cardinality", "2"]])
+def test_paired_native_cli_uses_frozen_extensions(paired_benchmark, tmp_path, mode):
+    installed = Path(importlib.import_module("rensa.rensa").__file__)
+    paths = []
+    for label in ("base", "head"):
+        path = tmp_path / label / installed.name
+        path.parent.mkdir()
+        shutil.copy2(installed, path)
+        paths.append(path)
+    output = tmp_path / "paired.json"
+    sizes = [0, 8] if "--prehashed" in mode else [1, 8]
+    subprocess.run([
+        sys.executable, paired_benchmark.__file__,
+        "--base-extension", str(paths[0]), "--head-extension", str(paths[1]),
+        "--output-json", str(output), "--rows", "8", "--max-input-tokens", "16",
+        "--sizes", *map(str, sizes), "--num-perm", "128",
+        "--min-sample-seconds", "0.001", "--warmup-seconds", "0", *mode,
+    ], check=True, text=True, capture_output=True, timeout=30)
+    report = json.loads(output.read_text())
+    assert report["config"]["repetitions"] == 6
+    digest = hashlib.sha256(installed.read_bytes()).hexdigest()
+    assert {entry["sha256"] for entry in report["extensions"].values()} == {digest}
+    assert report["extensions"]["base"]["path"] != report["extensions"]["head"]["path"]
+    assert report["environment"]["flags"]["RENSA_PIPELINE_QUEUE_CAP"] == "0"
+    assert all(report["environment"]["flags"][name] == "1" for name in paired_benchmark.THREAD_ENV)
+    assert len(report["results"]) == 2
+    for row, size in zip(report["results"], sizes):
+        assert row["rows"] == min(8, 16 // max(size, 1))
+        assert len(row["input_sha256"]) == 64
+        assert len({tuple(order) for order in row["engine_order"]}) == 6
+        for cycle, order in enumerate(row["engine_order"]):
+            assert (order.index("base") < order.index("head")) == (cycle % 2 == 0)
+        assert row["samples"]["base"]["sha256"] == row["samples"]["head"]["sha256"]
+        for sample in row["samples"].values():
+            assert len(sample["seconds"]) == len(sample["iterations"]) == 6
+            assert all(value > 0 for value in sample["seconds"])
+        assert len(row["paired_head_over_base"]) == len(row["paired_fastsketch_over_head"]) == 6
+        if "--repeat-cardinality" in mode:
+            assert row["distinct_tokens_per_row"] == min(size, 2)
+
+
+def test_paired_measure_rejects_different_r_signatures(paired_benchmark):
+    operations = {
+        "base": (lambda: [1], lambda result: result),
+        "head": (lambda: [2], lambda result: result),
+        "fastsketch": (lambda: [3], lambda result: result),
+    }
+    with pytest.raises(RuntimeError, match="Base/head signatures differ"):
+        paired_benchmark.paired_measure(operations, 1, 0, 0)
+
+
+@pytest.mark.parametrize("engine", ["base", "head", "fastsketch"])
+def test_paired_measure_rejects_changes_between_intervals(paired_benchmark, engine):
+    operations = {name: (lambda: [0], lambda result: result)
+                  for name in ("base", "head", "fastsketch")}
+    # Each invocation of measure sees locally stable output; the paired loop
+    # must also check invariance between its warmup and subsequent intervals.
+    values = iter([0, 0, 1, 1])
+    operations[engine] = (lambda: [next(values)], lambda result: result)
+    with pytest.raises(RuntimeError, match=f"{engine} signatures changed"):
+        paired_benchmark.paired_measure(operations, 1, 0, 0)
+
+
+@pytest.mark.parametrize("arguments, message", [
+    (["--rows", "0"], "must be positive"),
+    (["--sizes", "-1"], "sizes must be nonnegative"),
+    (["--num-perm", "3"], "power-of-two"),
+    (["--prehashed", "--sizes", "9", "--max-input-tokens", "8"], "cannot exceed"),
+    (["--sizes", "0"], "rejects empty rows"),
+    (["--repeat-cardinality", "2"], "requires prehashed mode"),
+    (["--min-sample-seconds", "nan"], "finite and nonnegative"),
+    (["--warmup-seconds", "-1"], "finite and nonnegative"),
+    (["--seed", "4294967296"], "unsigned 32-bit"),
+])
+def test_paired_cli_input_guards(paired_benchmark, monkeypatch, capsys, arguments, message):
+    monkeypatch.setattr(sys, "argv", [
+        "paired_sketch_benchmark", "--base-extension", "base.so",
+        "--head-extension", "head.so", "--output-json", "unused.json", *arguments,
+    ])
+    with pytest.raises(SystemExit) as error:
+        paired_benchmark.main()
+    assert error.value.code == 2
+    assert message in capsys.readouterr().err

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,63 @@
+import argparse
+import hashlib
+import importlib
+import json
+import pickle
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("module_name", ["simple_benchmark", "full_benchmark"])
+def test_benchmark_records_order_sensitive_duplicate_decisions(
+    module_name, monkeypatch, tmp_path, capsys
+):
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "benchmarks"))
+    benchmark = importlib.import_module(module_name)
+    flags = {
+        engine: [index % 2 == 0, index % 2 != 0]
+        for index, engine in enumerate(benchmark.ENGINE_KEYS)
+    }
+    monkeypatch.setattr(
+        benchmark, "run_engine", lambda **kwargs: ({}, flags[kwargs["engine"]])
+    )
+    token_sets = [["first"], ["second"]]
+    if module_name == "simple_benchmark":
+        result = benchmark.run_once(
+            token_sets, list(benchmark.ENGINE_KEYS), 128, 8, 0.8, 42
+        )
+    else:
+        token_cache = tmp_path / "tokens.pkl"
+        token_cache.write_bytes(pickle.dumps(token_sets))
+        for key in benchmark.THREAD_ENV_VARS:
+            monkeypatch.setenv(key, "1")
+        benchmark.run_once(argparse.Namespace(
+            token_cache=token_cache,
+            order=",".join(benchmark.ENGINE_KEYS),
+            run_threads=1,
+            expected_token_cache_sha=benchmark.sha256_file(token_cache),
+            num_perm=128,
+            num_bands=8,
+            threshold=0.8,
+            seed=42,
+        ))
+        result = json.loads(capsys.readouterr().out)
+
+    assert result["duplicate_flags_sha256"] == {
+        engine: hashlib.sha256(bytes(decisions)).hexdigest()
+        for engine, decisions in flags.items()
+    }
+    assert len(set(result["duplicate_flags_sha256"].values())) == 2
+
+
+def test_installed_fastsketch_detects_exact_duplicates(monkeypatch):
+    pytest.importorskip("FastSketchLSH")
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "benchmarks"))
+    benchmark = importlib.import_module("full_benchmark")
+    metrics, flags = benchmark.run_fastsketch(
+        [["alpha", "beta"], ["gamma", "delta"], ["alpha", "beta"]],
+        num_perm=128, num_bands=8, seed=42, threads=1,
+    )
+    assert flags == [True, False, True]
+    assert metrics["rows_removed"] == 2
+    assert metrics["rows_remaining"] == 1

--- a/tests/test_inline_dedup.py
+++ b/tests/test_inline_dedup.py
@@ -397,3 +397,29 @@ class TestInlineDeduplication:
 
         with pytest.raises(ValueError, match="num_perm is not configured"):
             dedup.is_duplicate_pairs([("doc0", ["alpha", "beta"])])
+
+
+@pytest.mark.parametrize("operation", ["clear", "remove_last", "remove_missing"])
+def test_cminhash_deduplicator_preserves_explicit_num_perm(operation):
+    dedup = CMinHashDeduplicator(threshold=0.8, num_perm=64)
+    if operation != "remove_missing":
+        assert dedup.add_pairs([("first", ["alpha"])]) == [True]
+    if operation == "clear":
+        dedup.clear()
+    else:
+        assert dedup.remove("first") is (operation == "remove_last")
+    assert dedup.add_pairs([("second", ["beta"])]) == [True]
+    incompatible = CMinHash(num_perm=32, seed=42)
+    with pytest.raises(ValueError, match="num_perm mismatch"):
+        dedup.add("incompatible", incompatible)
+
+
+@pytest.mark.parametrize("operation", ["clear", "remove"])
+def test_cminhash_deduplicator_resets_inferred_num_perm(operation):
+    dedup = CMinHashDeduplicator(threshold=0.8)
+    assert dedup.add("first", CMinHash(num_perm=64, seed=42))
+    if operation == "clear":
+        dedup.clear()
+    else:
+        assert dedup.remove("first")
+    assert dedup.add("second", CMinHash(num_perm=32, seed=42))

--- a/tests/test_inline_dedup.py
+++ b/tests/test_inline_dedup.py
@@ -423,3 +423,76 @@ def test_cminhash_deduplicator_resets_inferred_num_perm(operation):
     else:
         assert dedup.remove("first")
     assert dedup.add("second", CMinHash(num_perm=32, seed=42))
+
+
+@pytest.mark.parametrize("num_perm", [1, 7, 8, 17, 128])
+@pytest.mark.parametrize("threshold", [0.0, 0.1, 0.8, 1.0])
+def test_cminhash_exact_index_matches_full_scan(num_perm, threshold):
+    dedup = CMinHashDeduplicator(threshold, num_perm=num_perm)
+    reference = {}
+
+    def signature(index):
+        value = CMinHash(num_perm=num_perm, seed=42)
+        if index:
+            value.update([f"token-{index}", f"group-{index % 13}"])
+        return value
+
+    def insert(key, value):
+        expected = key not in reference and not any(
+            value.jaccard(existing) >= threshold
+            for existing in reference.values()
+        )
+        assert dedup.add(key, value) == expected
+        if expected:
+            reference[key] = value
+
+    for index in range(200):
+        insert(str(index), signature(index))
+    for index in range(240):
+        value = signature(index)
+        expected = {
+            key for key, existing in reference.items()
+            if value.jaccard(existing) >= threshold
+        }
+        assert dedup.is_duplicate("unknown", value) == bool(expected)
+        assert set(dedup.get_duplicates(value)) == expected
+    for index in range(0, 200, 2):
+        key = str(index)
+        assert dedup.remove(key) == (reference.pop(key, None) is not None)
+        insert(key, signature(index + 300))
+    for key, value in reference.items():
+        assert dedup.is_duplicate(key, value)
+    dedup.clear()
+    assert dedup.is_empty()
+    assert dedup.get_duplicates(signature(0)) == []
+    assert dedup.add("new", signature(0))
+
+
+def test_cminhash_exact_index_keeps_partial_batch_and_key_semantics():
+    dedup = CMinHashDeduplicator(0.8, num_perm=128)
+    entries = [(str(i), [f"unique-{i}"]) for i in range(200)]
+    assert dedup.add_pairs(entries) == [True] * 200
+    with pytest.raises(TypeError):
+        dedup.add_pairs([("accepted", ["new-token"]), ("invalid", [123])])
+    assert dedup.is_duplicate_pairs([("accepted", ["different-token"])]) == [True]
+    assert dedup.remove("accepted")
+    assert dedup.add_pairs([("accepted", ["replacement-token"])]) == [True]
+    incompatible = CMinHash(num_perm=64, seed=42)
+    with pytest.raises(ValueError, match="num_perm mismatch"):
+        dedup.is_duplicate("accepted", incompatible)
+
+
+def test_cminhash_exact_index_shrinks_and_relearns_dimensions():
+    dedup = CMinHashDeduplicator(0.8)
+    for num_perm in [64, 128]:
+        signatures = []
+        for index in range(200):
+            value = CMinHash(num_perm=num_perm, seed=42)
+            value.update([f"unique-{index}"])
+            signatures.append(value)
+            assert dedup.add(str(index), value)
+        for index, value in enumerate(signatures):
+            assert dedup.is_duplicate("unknown", value)
+            assert dedup.remove(str(index))
+            assert not dedup.is_duplicate("unknown", value)
+        assert dedup.is_empty()

--- a/tests/test_input_safety.py
+++ b/tests/test_input_safety.py
@@ -1,0 +1,134 @@
+import os
+import subprocess
+import sys
+
+import pytest
+from rensa import CMinHash, RMinHash
+
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="Python buffer methods require Python 3.12"
+)
+
+
+class MutatingBuffer:
+    def __init__(self, target, phase):
+        self.target = target
+        self.phase = phase
+
+    def __buffer__(self, flags):
+        if self.phase == "acquire":
+            self.target.clear()
+        return memoryview(b"token")
+
+    def __release_buffer__(self, view):
+        if self.phase == "release":
+            self.target.clear()
+
+
+@pytest.mark.parametrize("phase", ["acquire", "release"])
+@pytest.mark.parametrize("prefix", [[], ["first"], [b"first"], [bytearray(b"first")]])
+@pytest.mark.parametrize("minhash", [RMinHash, CMinHash])
+def test_token_list_resize_during_buffer_callback(minhash, prefix, phase):
+    tokens = list(prefix)
+    tokens.extend([MutatingBuffer(tokens, phase), b"last"])
+    with pytest.raises(RuntimeError, match="token list changed size"):
+        minhash(num_perm=16, seed=42).update(tokens)
+
+
+@pytest.mark.parametrize("phase", ["acquire", "release"])
+@pytest.mark.parametrize("prefix", [[], [b"first"], [bytearray(b"first")]])
+def test_byte_token_list_resize_during_buffer_callback(prefix, phase):
+    tokens = list(prefix)
+    tokens.extend([MutatingBuffer(tokens, phase), b"last"])
+    with pytest.raises(RuntimeError, match="token list changed size"):
+        RMinHash.digest_matrix_from_token_byte_sets([tokens], 16, 42)
+
+
+@pytest.mark.parametrize("phase", ["acquire", "release"])
+def test_sampled_token_list_resize_during_buffer_callback(monkeypatch, phase):
+    monkeypatch.setenv("RENSA_RHO_TOKEN_BUDGET", "2")
+    tokens = []
+    tokens.extend(MutatingBuffer(tokens, phase) for _ in range(512))
+    with pytest.raises(RuntimeError, match="token list changed size"):
+        RMinHash.digest_matrix_from_token_sets_rho([tokens], 16, 42)
+
+
+@pytest.mark.parametrize("phase", ["acquire", "release"])
+def test_rho_fallback_outer_list_resize(phase):
+    script = f"""
+from rensa import RMinHash
+class Exporter:
+    def __buffer__(self, flags):
+        if {phase!r} == 'acquire':
+            corpus.clear()
+        return memoryview(b'token')
+    def __release_buffer__(self, view):
+        if {phase!r} == 'release':
+            corpus.clear()
+corpus = [[b'first']] + [[Exporter()] for _ in range(31)]
+try:
+    RMinHash.digest_matrix_from_token_sets_rho(corpus, 16, 42)
+except IndexError:
+    pass
+else:
+    raise AssertionError('expected resized outer list to be rejected')
+"""
+    env = dict(os.environ, RAYON_NUM_THREADS="2", RENSA_DOC_PAR_BATCH_SIZE="32",
+               RENSA_RHO_RAW_PARALLEL="1")
+    result = subprocess.run([sys.executable, "-c", script], env=env,
+                            capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("phase", ["acquire", "release"])
+@pytest.mark.parametrize("minhash", [RMinHash, CMinHash])
+def test_buffer_destructor_resize_after_callback(minhash, phase):
+    tokens = []
+    released = []
+
+    class Exporter:
+        def __buffer__(self, flags):
+            if phase == "acquire":
+                tokens[0] = b"replacement"
+            return memoryview(b"token")
+
+        def __release_buffer__(self, view):
+            if phase == "release":
+                tokens[0] = b"replacement"
+
+        def __del__(self):
+            released.append(True)
+            tokens.clear()
+
+    tokens.extend([Exporter(), b"last"])
+    with pytest.raises(RuntimeError, match="token list changed size"):
+        minhash(num_perm=16, seed=42).update(tokens)
+    assert released == [True]
+
+
+@pytest.mark.parametrize("minhash", [RMinHash, CMinHash])
+def test_same_size_list_replacement_after_subclass_token(minhash):
+    tokens = [type("Token", (str,), {})("first")]
+
+    class Exporter:
+        def __buffer__(self, flags):
+            tokens[:] = [b"replacement", b"replacement", b"last"]
+            return memoryview(b"token")
+
+    tokens.extend([Exporter(), "old last"])
+    result = minhash(num_perm=16, seed=42)
+    result.update(tokens)
+    expected = minhash(num_perm=16, seed=42)
+    expected.update(["first", b"token", b"last"])
+    assert result.digest() == expected.digest()
+
+
+@pytest.mark.parametrize("queue_cap", ["0", "2"])
+@pytest.mark.parametrize("phase", ["acquire", "release"])
+def test_classic_matrix_rejects_missing_outer_rows(monkeypatch, queue_cap, phase):
+    monkeypatch.setenv("RENSA_PIPELINE_QUEUE_CAP", queue_cap)
+    corpus = []
+    corpus.extend([[MutatingBuffer(corpus, phase)], [b"last"]])
+    with pytest.raises(ValueError, match="document list changed size"):
+        RMinHash.digest_matrix_from_token_sets(corpus, 16, 42)

--- a/tests/test_lsh_regressions.py
+++ b/tests/test_lsh_regressions.py
@@ -1,0 +1,50 @@
+import struct
+
+import pytest
+
+from rensa import RMinHash, RMinHashLSH
+
+
+@pytest.mark.parametrize(
+    "method", ["insert_many", "insert_matrix", "insert_matrix_and_query_duplicate_flags"]
+)
+def test_sequential_keys_reject_overflow_without_replacing_zero(method):
+    maximum_key = (1 << (8 * struct.calcsize("P"))) - 1
+    minhash = RMinHash(num_perm=16, seed=42)
+    minhash.update(["alpha"])
+    lsh = RMinHashLSH(threshold=0.8, num_perm=16, num_bands=4)
+    existing = RMinHash(num_perm=16, seed=42)
+    existing.update(["unrelated"])
+    lsh.insert(0, existing)
+
+    def rows(count):
+        if method == "insert_many":
+            return iter([minhash] * count)
+        return RMinHash.digest_matrix_from_token_sets(
+            [["alpha"]] * count, num_perm=16, seed=42
+        )
+
+    insert = getattr(lsh, method)
+    with pytest.raises(ValueError, match="maximum key"):
+        insert(rows(2), start_key=maximum_key)
+    assert lsh.query(existing) == [0]
+    if method != "insert_many":
+        assert lsh.query(minhash) == []
+    insert(rows(1), start_key=maximum_key)
+    assert lsh.query(minhash) == [maximum_key]
+    assert lsh.query(existing) == [0]
+
+
+def test_duplicate_flags_count_distinct_keys_across_bands():
+    minhash = RMinHash(num_perm=16, seed=42)
+    minhash.update(["alpha"])
+    matrix = RMinHash.digest_matrix_from_token_sets(
+        [["alpha"]], num_perm=16, seed=42
+    )
+    lsh = RMinHashLSH(threshold=0.8, num_perm=16, num_bands=4)
+    for keys, expected in [((), False), ((7,), False), ((7, 9), True)]:
+        for key in keys:
+            lsh.insert(key, minhash)
+        assert lsh.query_duplicate_flags([minhash]) == [expected]
+        assert lsh.query_duplicate_flags_matrix(matrix) == [expected]
+        assert (len(lsh.query(minhash)) > 1) is expected

--- a/tests/test_rensa.py
+++ b/tests/test_rensa.py
@@ -73,16 +73,44 @@ def test_minhash_jaccard_rejects_seed_mismatch(minhash_type):
         left.jaccard(right)
 
 
-def test_rminhash_serialization_roundtrip():
-    m = RMinHash(num_perm=5, seed=2023)
-    m.update(["serialize", "this"])
-    digest_before = m.digest()
-
+@pytest.mark.parametrize("num_perm", [5, 128, 129])
+def test_rminhash_serialization_roundtrip_and_legacy_rejection(num_perm):
     import pickle
-    data = pickle.dumps(m)
-    m2 = pickle.loads(data)
 
-    assert m2.digest() == digest_before, "Deserialized RMinHash should have the same digest"
+    sketch = RMinHash(num_perm=num_perm, seed=42)
+    sketch.update(["first", "second"])
+    restored = pickle.loads(pickle.dumps(sketch))
+    assert restored.digest() == sketch.digest()
+    restored.update(["third"])
+    sketch.update(["third"])
+    assert restored.digest() == sketch.digest()
+    assert RMinHash.ALGORITHM_VERSION == 2
+
+    # Actual state emitted by version 1 for k=2, seed=42, {a,b}.
+    legacy = bytes.fromhex("022a02b4ecd38e02b9a6aff201")
+    before = sketch.digest()
+    with pytest.raises(ValueError, match="rebuild"):
+        sketch.__setstate__(legacy)
+    assert sketch.digest() == before
+
+
+def test_lsh_serialization_roundtrip_and_legacy_rejection():
+    import pickle
+
+    sketch = RMinHash(num_perm=128, seed=42)
+    sketch.update(["first", "second"])
+    index = RMinHashLSH(threshold=0.8, num_perm=128, num_bands=8)
+    index.insert(0, sketch)
+    restored = pickle.loads(pickle.dumps(index))
+    assert restored.query(sketch) == [0]
+
+    # Actual version 1 index containing key 0 and the {a,b} sketch above.
+    legacy = bytes.fromhex(
+        "9a9999999999e93f020102010194c48cabbca2f1ac1c010001000194c48cabbca2f1ac1c"
+    )
+    with pytest.raises(ValueError, match="rebuild"):
+        restored.__setstate__(legacy)
+    assert restored.query(sketch) == [0]
 
 
 def test_cminhash_serialization_roundtrip_and_legacy_rejection():

--- a/tests/test_rensa.py
+++ b/tests/test_rensa.py
@@ -321,6 +321,174 @@ def test_rminhash_flat_token_hash_matrix_matches_default_path():
     assert from_flat_buffers == baseline
 
 
+@pytest.mark.parametrize("digest", [
+    pytest.param(lambda values: RMinHash.digest_matrix_from_token_hash_sets(
+        [values], 16, 42).to_rows(), id="r_batch"),
+    pytest.param(lambda values: RMinHash.digest_matrix_from_flat_token_hashes(
+        values, [0, len(values)], 16, 42).to_rows(), id="r_flat"),
+    pytest.param(lambda values: CMinHash.digests64_from_token_hash_sets(
+        [values], 16, 42), id="c_batch"),
+])
+def test_prehashed_requires_integer_values(digest):
+    class IndexValue:
+        def __index__(self):
+            raise AssertionError("prehashed conversion must not invoke __index__")
+
+    class IntegerValue(int):
+        def __index__(self):
+            raise AssertionError("integer subclasses must use their stored value")
+
+    assert digest([1, IntegerValue(2)]) == digest([1, 2])
+    with pytest.raises(TypeError, match="unsigned 64-bit integer"):
+        digest([1, IndexValue()])
+
+
+@pytest.mark.parametrize("digest", [
+    pytest.param(lambda values: RMinHash.digest_matrix_from_token_hash_sets(
+        [values], 16, 42).to_rows(), id="r_batch"),
+    pytest.param(lambda values: RMinHash.digest_matrix_from_token_hash_sets_rho(
+        [values], 16, 42).to_rows(), id="rho_batch"),
+    pytest.param(lambda values: RMinHash.digest_matrix_from_flat_token_hashes(
+        values, [0, len(values)], 16, 42).to_rows(), id="r_flat"),
+    pytest.param(lambda values: RMinHash.digest_matrix_from_flat_token_hashes_rho(
+        values, [0, len(values)], 16, 42).to_rows(), id="rho_flat"),
+    pytest.param(lambda values: CMinHash.digests64_from_token_hash_sets(
+        [values], 16, 42), id="c_batch"),
+])
+def test_prehashed_integer_buffers_require_native_byte_order(digest):
+    np = pytest.importorskip("numpy")
+    values = [1, 0x0102030405060708, (1 << 64) - 2]
+    native = np.array(values, dtype=np.uint64)
+    expected = digest(values)
+    assert digest(native) == expected
+    assert digest(memoryview(native).toreadonly()) == expected
+
+    foreign = np.array(values, dtype=np.dtype(np.uint64).newbyteorder("S"))
+    with pytest.raises(TypeError, match="unsigned 64-bit integer"):
+        digest(foreign)
+
+
+@pytest.mark.parametrize("width", [2, 4, 8])
+@pytest.mark.parametrize("digest", [
+    RMinHash.digest_matrix_from_flat_token_hashes,
+    RMinHash.digest_matrix_from_flat_token_hashes_rho,
+])
+def test_row_offset_buffers_do_not_reinterpret_foreign_byte_order(width, digest):
+    np = pytest.importorskip("numpy")
+    values = [1, 2, 3]
+    native = np.array([0, 1, 3], dtype=f"u{width}")
+    expected = digest(values, [0, 1, 3], 16, 42).to_rows()
+    assert digest(values, native, 16, 42).to_rows() == expected
+
+    foreign = native.astype(native.dtype.newbyteorder("S"))
+    try:
+        actual = digest(values, foreign, 16, 42).to_rows()
+    except ValueError as error:
+        assert "row_offsets must be an unsigned integer" in str(error)
+    else:
+        # A rejected typed view may fall back to correct numeric iteration.
+        assert actual == expected
+
+
+@pytest.mark.parametrize("threads", [1, 2])
+def test_rminhash_large_flat_buffer_views_match_owned_inputs(threads):
+    code = """
+from array import array
+import sys
+from rensa import RMinHash
+
+size = 3 * 65536 + 19
+mask = (1 << 64) - 1
+original = array('Q', ((i * 0x9e3779b97f4a7c15) & mask for i in range(size)))
+storage = array('Q', [7]) + original + array('Q', [11])
+view = memoryview(storage)[1:-1]
+readonly = view.toreadonly()
+boundaries = [0, 0, 65535, 65536, 65536, size]
+
+for k in (17, 128):
+    for offsets in (boundaries, [0, size]):
+        expected = RMinHash.digest_matrix_from_flat_token_hashes(
+            list(original), offsets, k, 42).to_rows()
+        offset_view = memoryview(array('Q', offsets)).toreadonly()
+        for source in (original, view, readonly):
+            actual = RMinHash.digest_matrix_from_flat_token_hashes(
+                source, offset_view, k, 42).to_rows()
+            assert actual == expected
+assert storage[0] == 7 and storage[-1] == 11
+assert list(view) == list(original)
+
+# Offset iteration runs before token snapshots for every size/input path.
+before = RMinHash.digest_matrix_from_flat_token_hashes([42], [0, 1], 128, 42).to_rows()
+changed = RMinHash.digest_matrix_from_flat_token_hashes([42, 99], [0, 2], 128, 42).to_rows()
+assert changed != before
+for length in (8, 65537):
+    for values in (array('Q', [42]) * length, [42] * length):
+        sources = [values]
+        if isinstance(values, array):
+            sources.append(memoryview(values).toreadonly())
+        for source in sources:
+            values[-1] = 42
+            iterations = []
+            class ChangingOffsets:
+                def __iter__(self):
+                    iterations.append(True)
+                    values[-1] = 99
+                    return iter([0, length])
+            actual = RMinHash.digest_matrix_from_flat_token_hashes(
+                source, ChangingOffsets(), 128, 42).to_rows()
+            assert actual == changed
+            assert iterations == [True]
+
+# A readonly view still has a writable alias. Later calls must observe writes.
+view[:] = memoryview(array('Q', [99]) * size)
+expected = RMinHash.digest_matrix_from_flat_token_hashes([99], [0, 1], 128, 42)
+actual = RMinHash.digest_matrix_from_flat_token_hashes(readonly, [0, size], 128, 42)
+assert actual.to_rows() == expected.to_rows()
+
+for offsets in ([], [0], [1, size], [0, size - 1], [0, size + 1], [0, 2, 1, size]):
+    try:
+        RMinHash.digest_matrix_from_flat_token_hashes(readonly, offsets, 128, 42)
+    except ValueError as error:
+        assert 'row_offsets must start at 0' in str(error)
+    else:
+        raise AssertionError('invalid row offsets were accepted')
+try:
+    RMinHash.digest_matrix_from_flat_token_hashes(view[::2], [0, (size + 1) // 2], 128, 42)
+except TypeError as error:
+    assert 'unsigned 64-bit integer' in str(error)
+else:
+    raise AssertionError('noncontiguous input was accepted')
+
+if sys.version_info >= (3, 12):
+    class Exporter:
+        def __init__(self, values):
+            self.values = values
+            self.events = []
+        def __buffer__(self, flags):
+            self.events.append('acquire')
+            return memoryview(self.values)
+        def __release_buffer__(self, view):
+            self.events.append('release')
+        def __iter__(self):
+            return iter(self.values)
+    for values in (array('Q', [1, 2]), original, array('B', [1, 2])):
+        exporter = Exporter(values)
+        expected = RMinHash.digest_matrix_from_flat_token_hashes(
+            list(values), [0, len(values)], 17, 42).to_rows()
+        actual = RMinHash.digest_matrix_from_flat_token_hashes(
+            exporter, [0, len(values)], 17, 42).to_rows()
+        assert actual == expected
+        assert exporter.events == ['acquire', 'release']
+print('PASS')
+"""
+    env = dict(os.environ, RAYON_NUM_THREADS=str(threads),
+               RENSA_MAX_PERM_CACHE_HASHES="0")
+    result = subprocess.run([sys.executable, "-c", code], env=env,
+                            capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "PASS"
+
+
 def test_rminhash_rho_matrix_apis_are_consistent():
     token_sets = [
         ["alpha", "beta", "gamma"],

--- a/tests/test_rensa.py
+++ b/tests/test_rensa.py
@@ -316,25 +316,44 @@ def test_rminhash_rho_source_token_counts_are_reported():
     assert matrix.get_rho_source_token_counts() == [1, 3, 0]
 
 
-def test_rminhash_rho_adaptive_budget_is_deterministic_across_thread_counts():
+@pytest.mark.parametrize("num_perm", [64, 128])
+def test_rminhash_rho_adaptive_budget_is_deterministic_across_thread_counts(num_perm):
     code = """
 import json
-from rensa import RMinHash
-token_sets = [
-    ["tok" + str(i % 5) for i in range(4 + (doc_idx % 40))]
-    for doc_idx in range(96)
-]
+from rensa import RMinHash, RMinHashLSH
+import os
+token_sets = []
+for doc_idx in range(384):
+    size = (0, 1, 7, 8, 31, 64, 97, 256)[doc_idx % 8]
+    tokens = ["tok" + str(i % 37) for i in range(size)]
+    if doc_idx % 6 == 2:
+        tokens = [token + "é" for token in tokens]
+    elif doc_idx % 6 == 3:
+        tokens = [token.encode() for token in tokens]
+    elif doc_idx % 6 == 4:
+        tokens = tuple(tokens)
+    elif doc_idx % 6 == 5:
+        tokens = [bytearray(token.encode()) for token in tokens]
+    token_sets.append(tokens)
+num_perm = int(os.environ["TEST_NUM_PERM"])
 matrix = RMinHash.digest_matrix_from_token_sets_rho(
-    token_sets, num_perm=64, seed=42, probes=4
+    token_sets, num_perm=num_perm, seed=42, probes=4
 )
-print(json.dumps(matrix.to_rows()))
+lsh = RMinHashLSH(0.8, num_perm, 8)
+flags = lsh.query_duplicate_flags_matrix_one_shot(matrix)
+print(json.dumps([matrix.to_rows(), matrix.get_rho_source_token_counts(),
+                 matrix.get_rho_non_empty_counts(), flags,
+                 lsh.get_last_one_shot_sparse_verify_checks(),
+                 lsh.get_last_one_shot_sparse_verify_passes()]))
 """
 
-    def run_with_threads(threads: int) -> list[list[int]]:
+    def run_with_threads(threads: int, raw: bool):
         env = os.environ.copy()
         env["RAYON_NUM_THREADS"] = str(threads)
         env["RENSA_RHO_MEDIUM_TOKEN_BUDGET"] = "20"
         env["RENSA_RHO_MEDIUM_TOKEN_THRESHOLD"] = "96"
+        env["RENSA_RHO_RAW_PARALLEL"] = str(int(raw))
+        env["TEST_NUM_PERM"] = str(num_perm)
         proc = subprocess.run(
             [sys.executable, "-c", code],
             text=True,
@@ -344,7 +363,9 @@ print(json.dumps(matrix.to_rows()))
         )
         return json.loads(proc.stdout)
 
-    assert run_with_threads(1) == run_with_threads(8)
+    expected = run_with_threads(1, False)
+    assert run_with_threads(8, True) == expected
+    assert run_with_threads(8, False) == expected
 
 
 def test_rminhashlsh_sparse_required_band_matches_is_monotonic():

--- a/tests/test_rensa.py
+++ b/tests/test_rensa.py
@@ -85,6 +85,29 @@ def test_rminhash_serialization_roundtrip():
     assert m2.digest() == digest_before, "Deserialized RMinHash should have the same digest"
 
 
+def test_cminhash_serialization_roundtrip_and_legacy_rejection():
+    import pickle
+
+    sketch = CMinHash(num_perm=129, seed=42)
+    sketch.update(["first", "second"])
+    restored = pickle.loads(pickle.dumps(sketch))
+    assert restored.digest_u64() == sketch.digest_u64()
+    restored.update(["third"])
+    sketch.update(["third"])
+    assert restored.digest_u64() == sketch.digest_u64()
+    assert CMinHash.ALGORITHM_VERSION == 2
+
+    # Actual state emitted by the affine implementation for k=2, seed=42, {a,b}.
+    legacy = bytes.fromhex(
+        "022a02e180a0e5fca1bea5a001eedbb3c6adc1dd959c019fd1d9a3f4a993bbd001"
+        "91efbcbbc5ae90cf518ddb93e1b09f9ff0fb01b8ebe0e680ece7beb301"
+    )
+    before = sketch.digest_u64()
+    with pytest.raises(ValueError, match="rebuild"):
+        sketch.__setstate__(legacy)
+    assert sketch.digest_u64() == before
+
+
 def test_rminhash_update_accepts_iterable_bytes_like_tokens():
     m = RMinHash(num_perm=32, seed=77)
     initial_digest = m.digest()

--- a/tests/test_rensa.py
+++ b/tests/test_rensa.py
@@ -63,6 +63,16 @@ def test_cminhash_jaccard_rejects_num_perm_mismatch():
         m1.jaccard(m2)
 
 
+@pytest.mark.parametrize("minhash_type", [RMinHash, CMinHash])
+def test_minhash_jaccard_rejects_seed_mismatch(minhash_type):
+    left = minhash_type(num_perm=128, seed=1)
+    right = minhash_type(num_perm=128, seed=2)
+    left.update(["same", "tokens"])
+    right.update(["same", "tokens"])
+    with pytest.raises(ValueError, match="seed mismatch"):
+        left.jaccard(right)
+
+
 def test_rminhash_serialization_roundtrip():
     m = RMinHash(num_perm=5, seed=2023)
     m.update(["serialize", "this"])


### PR DESCRIPTION
R-MinHash v2 replaces the full token-by-coordinate scan with three seeded bucket rounds and a SIMD fallback for empty coordinates. It uses every token and preserves order, duplicate, merge, and incremental-update invariance. Sparse sketches avoid redundant setup, dense sketches skip fallback, and large serial prehashed buffers avoid an input copy. Conservative rank filtering skips updates that cannot improve established minima. Runtime AVX-512 kernels accelerate mixing and fallback, load input and coefficients directly, vectorize fallback across tokens, and reuse the filtered output buffer. Long unfiltered conditional-update spans use the existing scalar mixer; initial fills, affine fallback and filtered SIMD tails retain their existing paths.

C-MinHash v1's affine maps produced biased, correlated signatures. C-MinHash v2 follows the paper's circulant input rotation using separately seeded nonlinear permutations. The invalid affine sorting shortcut is removed; an exact candidate index accelerates streaming duplicate checks while retaining final signature verification. Both algorithms use practical pseudorandom hash families, so the papers' exact random-permutation guarantees are not claimed.

Both R-MinHash and C-MinHash require rebuilding version 1 signatures and indexes from original tokens. Legacy serialized states are rejected. Input handling validates dimensions, seeds and native byte order, preserves Python buffer lifetimes, and handles callbacks before borrowing token storage. Rho remains a separate approximate representation with different retrieval accuracy. No dependency was added.

Benchmarks now separate native sketch construction, prehashed CSR calls, and complete deduplication pipelines. They check input/output fingerprints, exact-Jaccard bias/RMSE, and retrieval precision/recall. CI compares R-MinHash against FastSketch per case, including empty through million-token prehashed rows. It records CPU features, native binary fingerprints and the actual FastSketch build selection, and tests Rust 1.83 compatibility. On AVX-512 runners, SIMD tests must select that backend, and an additional AVX2 control measures the same source and hardware. An optional manual diagnostic freezes both native builds and compares them in six balanced timing cycles, checking exact signatures after every sample. Existing performance gates remain unchanged.

Current revision `8d27a55` passes all **24 PR checks**, including Performance Check; Release is skipped in [run 34014714217](https://github.com/beowolx/rensa/actions/runs/34014714217). The performance VM exposes AVX2, with FastSketch using its baseline build. R-MinHash wins all 14 byte-input and all 14 prehashed cases. Against FastSketch measured in each version's phase, geometric-mean speed ratios rise from release `e056f18` **1.22x to 3.38x for bytes**, and **1.05x to 4.48x for prehashed input**. The AG News deduplication benchmark's ratio rises from **4.07x to 5.64x**; that pipeline uses the separate sampled rho path. Direct R-MinHash speedups against release are 2.81x/4.25x for the two full-set suites. Some tiny-input cases remain slower than the original release.

The latest source change addresses a measured dispatch cost. In the preceding [Intel 8370C run 33991908609](https://github.com/beowolx/rensa/actions/runs/33991908609), 65,536 prehashes/512 slots took 19.226 ms with default AVX-512 versus FastSketch's 16.889 ms. The same R-MinHash binary forced to its scalar bucket-mixing path took 17.377 ms with identical signatures, within the existing 5% gate. The new selector retains vectorized fills and filtered tails while using scalar mixing for long conditional updates. This candidate's Intel performance has not yet been confirmed: all three allocations of [manual run 34014742227](https://github.com/beowolx/rensa/actions/runs/34014742227) lacked AVX-512 and stopped at the hardware guard before building or benchmarking. The green AVX2 result does not resolve the previously recorded Intel gaps or establish a fastest-everywhere claim.

The successful PR run covers Rust quality, Rust 1.83 support, Python tests, platform wheels, accuracy and full benchmark smoke tests. Its detailed R-MinHash v2 accuracy results match the preceding `020d173` measurements exactly. The earlier density-filter result remains provisional because its same-version Intel controls failed amid phase drift; those results remain recorded in [manual run 33991965948](https://github.com/beowolx/rensa/actions/runs/33991965948). No performance threshold was changed and no actual benchmark failure was rerun in this validation pass.

CI reproduced R-MinHash RMSE improving from 0.030919 to 0.026062 at 128 slots and from 0.015112 to 0.012570 at 512. Corrected C-MinHash RMSE improved from 0.069488/0.065081 to 0.029646/0.014676. FastSketch's baseline build retained lower RMSE at 0.025458/0.011266; its AVX-512 build has different results and an observed input-order defect. Equal slot counts also differ in storage: R uses 32-bit slots, C/FastSketch 64-bit slots. All speed and accuracy rankings are scoped to the recorded cases and backend.
