### PR TITLE
Release Rensa 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "rensa"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "libmimalloc-sys",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rensa"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Luis Cardoso <luis@luiscardoso.dev>"]

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ deduplicator considered a duplicate.
 uv add rensa
 ```
 
+**Upgrading from 0.4.x or earlier:** Rensa 0.5.0 uses algorithm version 2 for
+R-MinHash and C-MinHash. Rebuild saved signatures, digest matrices and LSH indexes
+from the original tokens. Old serialized sketches and indexes are rejected;
+do not compare or combine raw digests from different algorithm versions.
+
 ## Usage
 
 ### Estimate similarity


### PR DESCRIPTION
Prepare Rensa 0.5.0 by updating the package version and its Cargo lock entry, and document the required migration from 0.4.x. Both sketch algorithms now use version 2; saved signatures, digest matrices, and LSH indexes must be rebuilt from original tokens.

The Python package version is derived from Cargo.toml. No dependency, native algorithm, or publishing-workflow changes are included. Existing tag CI publishes through PyPI Trusted Publishing.

Validation: locked Cargo metadata, uv lock validation, formatting/diff checks, and a release-wheel build plus isolated installation smoke test. Full PR checks must pass before merging and tagging.
